### PR TITLE
feat: Dual Docker image release (API-only/Full) with Swagger auto-generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,28 @@ jobs:
           cat coverage-summary.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+  # Test without default features (API-only build)
+  test-no-default-features:
+    name: Test (no default features)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build without default features
+        run: cargo build --no-default-features
+
+      - name: Run tests without default features
+        run: cargo test --no-default-features
+
   # Docker build check
   docker-build:
     name: Docker Build Check
@@ -278,12 +300,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image (no push)
+      - name: Build API-only Docker image (no push)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: deployments/docker/Dockerfile
           push: false
-          tags: registry-firewall:ci-check
+          tags: registry-firewall:ci-check-api
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build full Docker image (no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deployments/docker/Dockerfile.full
+          push: false
+          tags: registry-firewall:ci-check-full
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,16 @@ jobs:
             fi
             git log --pretty=format:"- %s (%h)" -n 50 >> release-notes.md
           fi
+          # Add Docker image information
+          echo "" >> release-notes.md
+          echo "## Docker Images" >> release-notes.md
+          echo "" >> release-notes.md
+          echo "| Variant | Image |" >> release-notes.md
+          echo "|---------|-------|" >> release-notes.md
+          echo "| API only (default) | \`ghcr.io/${{ github.repository }}:${TAG#v}\` |" >> release-notes.md
+          echo "| Full (with Web UI) | \`ghcr.io/${{ github.repository }}:${TAG#v}-full\` |" >> release-notes.md
+          echo "" >> release-notes.md
+          echo "> **Breaking Change**: The \`latest\` tag now points to the API-only image. For the image with Web UI, use the \`latest-full\` tag." >> release-notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,14 +44,43 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-features -- -D warnings
 
-      - name: Build
+      - name: Build (all features)
         run: cargo build --all-features
 
-      - name: Run tests
+      - name: Build (no default features)
+        run: cargo build --no-default-features
+
+      - name: Run tests (all features)
         run: cargo test --all-features
 
-  build-and-push-docker:
-    name: Build and Push Docker Image
+      - name: Run tests (no default features)
+        run: cargo test --no-default-features
+
+  generate-swagger:
+    name: Generate swagger.json
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Generate swagger.json
+        run: cargo run --no-default-features --features swagger-gen -- --generate-swagger
+
+      - name: Upload swagger.json as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: swagger-json
+          path: swagger.json
+
+  build-docker-api:
+    name: Build and Push Docker Image (API only)
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -74,8 +103,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
-        id: meta
+      - name: Extract metadata for API-only image
+        id: meta-api
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -85,14 +114,61 @@ jobs:
             type=semver,pattern={{major}},enable=${{ needs.test.outputs.is_prerelease == 'false' }}
             type=raw,value=latest,enable=${{ needs.test.outputs.is_prerelease == 'false' }}
 
-      - name: Build and push Docker image
+      - name: Build and push API-only Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: deployments/docker/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta-api.outputs.tags }}
+          labels: ${{ steps.meta-api.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+  build-docker-full:
+    name: Build and Push Docker Image (Full with Web UI)
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for full image
+        id: meta-full
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}-full
+            type=semver,pattern={{major}}.{{minor}}-full,enable=${{ needs.test.outputs.is_prerelease == 'false' }}
+            type=semver,pattern={{major}}-full,enable=${{ needs.test.outputs.is_prerelease == 'false' }}
+            type=raw,value=latest-full,enable=${{ needs.test.outputs.is_prerelease == 'false' }}
+
+      - name: Build and push full Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deployments/docker/Dockerfile.full
+          push: true
+          tags: ${{ steps.meta-full.outputs.tags }}
+          labels: ${{ steps.meta-full.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
@@ -100,7 +176,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [test, build-and-push-docker]
+    needs: [test, generate-swagger, build-docker-api, build-docker-full]
     permissions:
       contents: write
     steps:
@@ -108,6 +184,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Download swagger.json
+        uses: actions/download-artifact@v4
+        with:
+          name: swagger-json
 
       - name: Generate release notes
         run: |
@@ -133,3 +214,4 @@ jobs:
         with:
           prerelease: ${{ needs.test.outputs.is_prerelease }}
           body_path: release-notes.md
+          files: swagger.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,15 @@ clap = { version = "4", features = ["derive", "env"] }
 regex-lite = "0.1"
 glob = "0.3.3"
 
+# OpenAPI specification generation (optional, enabled by "swagger-gen" feature)
+utoipa = { version = "5", features = ["axum_extras", "chrono"], optional = true }
+utoipa-axum = { version = "0.2", optional = true }
+utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
+
 [features]
 default = ["webui"]
 webui = ["dep:rust-embed", "dep:mime_guess"]
+swagger-gen = ["dep:utoipa", "dep:utoipa-axum", "dep:utoipa-swagger-ui"]
 
 [dev-dependencies]
 mockall = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,12 +77,10 @@ glob = "0.3.3"
 # OpenAPI specification generation (optional, enabled by "swagger-gen" feature)
 utoipa = { version = "5", features = ["axum_extras", "chrono"], optional = true }
 utoipa-axum = { version = "0.2", optional = true }
-utoipa-swagger-ui = { version = "9", features = ["axum"], optional = true }
-
 [features]
 default = ["webui"]
 webui = ["dep:rust-embed", "dep:mime_guess"]
-swagger-gen = ["dep:utoipa", "dep:utoipa-axum", "dep:utoipa-swagger-ui"]
+swagger-gen = ["dep:utoipa", "dep:utoipa-axum"]
 
 [dev-dependencies]
 mockall = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ anyhow = "1"
 config = "0.14"
 url = "2"
 
-# Embed static files
-rust-embed = "8"
-mime_guess = "2"
+# Embed static files (optional, enabled by "webui" feature)
+rust-embed = { version = "8", optional = true }
+mime_guess = { version = "2", optional = true }
 
 # Git operations (for OpenSSF sync)
 git2 = "0.20"
@@ -73,6 +73,10 @@ clap = { version = "4", features = ["derive", "env"] }
 # Regex (lightweight)
 regex-lite = "0.1"
 glob = "0.3.3"
+
+[features]
+default = ["webui"]
+webui = ["dep:rust-embed", "dep:mime_guess"]
 
 [dev-dependencies]
 mockall = "0.12"

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /app
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
     pkg-config \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -42,6 +43,7 @@ FROM debian:bookworm-slim AS runtime
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
     ca-certificates \
     libssl3 \
     curl \

--- a/deployments/docker/Dockerfile.full
+++ b/deployments/docker/Dockerfile.full
@@ -1,10 +1,29 @@
-# registry-firewall API-only Dockerfile
+# registry-firewall Full Dockerfile (with Web UI)
 #
-# This Dockerfile builds the API-only image without Web UI.
-# For the full image with Web UI, use Dockerfile.full.
+# This Dockerfile builds the full image including Web UI.
+# For the API-only image, use Dockerfile.
 
 # ==============================================================================
-# Stage 1: Build the Rust application (API only, no webui feature)
+# Stage 1: Build the frontend
+# ==============================================================================
+FROM node:20-bookworm-slim AS node-build
+
+WORKDIR /app/web
+
+# Copy package files first for layer caching
+COPY web/package.json web/package-lock.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy frontend source
+COPY web/ ./
+
+# Build the frontend
+RUN npm run build
+
+# ==============================================================================
+# Stage 2: Build the Rust application (with webui feature)
 # ==============================================================================
 FROM rust:1-bookworm AS builder
 
@@ -20,23 +39,26 @@ RUN apt-get update && apt-get install -y \
 COPY Cargo.toml Cargo.lock ./
 
 # Create a dummy source file to build dependencies
-RUN mkdir -p src && \
+RUN mkdir -p src web/dist && \
     echo 'fn main() { println!("Dummy"); }' > src/main.rs && \
     echo 'pub fn lib() {}' > src/lib.rs
 
 # Build dependencies (this layer will be cached unless Cargo.toml/lock changes)
-RUN cargo build --release --no-default-features && \
+RUN cargo build --release --features webui && \
     cargo clean -p registry-firewall --release && \
     rm -rf src
 
-# Copy the actual source code (no web/ needed for API-only build)
+# Copy the actual source code
 COPY src src/
 
-# Build the application without webui feature
-RUN cargo build --release --no-default-features
+# Copy built frontend from node-build stage
+COPY --from=node-build /app/web/dist web/dist/
+
+# Build the application with webui feature
+RUN cargo build --release --features webui
 
 # ==============================================================================
-# Stage 2: Create the minimal runtime image
+# Stage 3: Create the minimal runtime image
 # ==============================================================================
 FROM debian:bookworm-slim AS runtime
 

--- a/deployments/docker/Dockerfile.full
+++ b/deployments/docker/Dockerfile.full
@@ -31,6 +31,7 @@ WORKDIR /app
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
     pkg-config \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -64,6 +65,7 @@ FROM debian:bookworm-slim AS runtime
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
+    --no-install-recommends \
     ca-certificates \
     libssl3 \
     curl \

--- a/docs/sdd/design-dual-docker.md
+++ b/docs/sdd/design-dual-docker.md
@@ -1,0 +1,968 @@
+# 技術設計書: Dual Docker Image Release + Swagger自動生成
+
+## 概要
+
+本ドキュメントは、要件定義書 `docs/sdd/requirements-dual-docker.md` に基づき、registry-firewallに「デュアルDockerイメージリリース」と「OpenAPI仕様の自動生成」機能を追加するための技術設計を定義する。
+
+### トレーサビリティ
+
+本設計書は以下の要件に対応する:
+- ストーリーA (REQ-101〜107): 軽量APIのみイメージ
+- ストーリーB (REQ-110〜116): フル機能GUI付きイメージ
+- ストーリーC (REQ-120〜129): OpenAPI仕様の自動生成
+- NFR-101〜NFR-109: 非機能要件
+
+---
+
+## 1. Cargo.toml features設計
+
+**対応要件**: REQ-101, REQ-102, REQ-105, REQ-120
+
+### 1.1 features定義
+
+```toml
+[features]
+default = ["webui"]
+webui = ["dep:rust-embed", "dep:mime_guess"]
+swagger-gen = ["dep:utoipa", "dep:utoipa-axum", "dep:utoipa-swagger-ui"]
+```
+
+#### 設計根拠
+
+- `default = ["webui"]`: 既存の動作（Web UI有効）を維持する（NFR-107）
+- `webui` featureに `rust-embed` と `mime_guess` を移動する（REQ-102）
+- `swagger-gen` featureは独立した機能であり、`webui` featureに依存しない
+  - swagger.json生成はAPIのみビルドでも実行可能にする（REQ-123）
+  - Swagger UI表示は `webui` featureと組み合わせて使用する（REQ-127, REQ-128）
+
+### 1.2 依存クレートの変更
+
+#### Before
+
+```toml
+[dependencies]
+# Embed static files
+rust-embed = "8"
+mime_guess = "2"
+```
+
+#### After
+
+```toml
+[dependencies]
+# Embed static files (optional, enabled by "webui" feature)
+rust-embed = { version = "8", optional = true }
+mime_guess = { version = "2", optional = true }
+
+# OpenAPI specification generation (optional, enabled by "swagger-gen" feature)
+utoipa = { version = "4", features = ["axum_extras", "chrono"], optional = true }
+utoipa-axum = { version = "0.1", optional = true }
+utoipa-swagger-ui = { version = "7", features = ["axum"], optional = true }
+```
+
+### 1.3 影響範囲
+
+- `Cargo.toml`: `[features]`セクション追加、`rust-embed`と`mime_guess`をoptional化
+- 既存の `cargo test --all-features` は引き続き動作する（制約事項）
+
+---
+
+## 2. モジュール構造の変更設計
+
+**対応要件**: REQ-103, REQ-104, REQ-105, REQ-121, REQ-122
+
+### 2.1 問題の分析
+
+現状の `src/webui/` モジュールは以下の2つの責務を混在している:
+
+| ファイル | 責務 | featureへの依存 |
+|---------|------|----------------|
+| `src/webui/mod.rs` | 静的ファイル埋め込み・配信（`rust-embed`, `mime_guess`使用） | `webui` feature必須 |
+| `src/webui/api.rs` | REST API型定義・ロジック（`DashboardStats`等） | feature不要（常に必要） |
+
+`src/server/router.rs` はすでに `crate::webui::api` をインポートしており、`webui` モジュール全体をcfg(feature)にすると`router.rs`が壊れる。
+
+### 2.2 モジュール再編成方針
+
+`src/webui/api.rs` の内容を `src/api/` に移動し、featureに依存しない独立モジュールとする。
+
+#### ディレクトリ構造（変更後）
+
+```
+src/
+├── lib.rs              # webui モジュールを cfg(feature = "webui") で条件付き
+├── api/                # 新規: API型定義・ロジック（feature非依存）
+│   ├── mod.rs          # pub mod types; pub mod handlers; のre-export
+│   ├── types.rs        # DashboardStats, BlockLogsResponse等の型定義
+│   └── handlers.rs     # build_dashboard_stats等のビジネスロジック
+└── webui/              # 静的ファイル配信のみ（cfg(feature = "webui")）
+    └── mod.rs          # Assets, serve_index(), serve_static()
+```
+
+**注意**: `src/webui/api.rs` の内容は `src/api/` に移動するが、後方互換のため `src/webui/mod.rs` からre-exportは行わない。代わりに `src/server/router.rs` のインポートパスを `crate::api` に変更する。
+
+### 2.3 src/lib.rs の変更
+
+#### Before
+
+```rust
+pub mod webui;
+```
+
+#### After
+
+```rust
+pub mod api;  // feature非依存: REST API型定義とロジック
+
+#[cfg(feature = "webui")]
+pub mod webui;  // webui feature時のみ: 静的ファイル配信
+```
+
+### 2.4 src/server/router.rs の変更
+
+#### インポート変更
+
+**Before**
+
+```rust
+use crate::webui::api::{
+    self, BlockLogsQuery, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, MAX_PATTERN_LENGTH,
+    MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
+};
+```
+
+**After**
+
+```rust
+use crate::api::{
+    self, BlockLogsQuery, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, MAX_PATTERN_LENGTH,
+    MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
+};
+```
+
+#### build_router() の変更
+
+**Before**
+
+```rust
+pub fn build_router<D: Database + 'static>(state: AppState<D>) -> Router {
+    let auth_manager = Arc::clone(&state.auth_manager);
+
+    Router::new()
+        // ... 省略 ...
+        // Web UI routes
+        .route("/ui", get(webui_index_handler))
+        .route("/ui/*path", get(webui_static_handler))
+        .layer(middleware::from_fn_with_state(
+            auth_manager,
+            auth_middleware,
+        ))
+        .with_state(state)
+}
+```
+
+**After**
+
+```rust
+pub fn build_router<D: Database + 'static>(state: AppState<D>) -> Router {
+    let auth_manager = Arc::clone(&state.auth_manager);
+
+    let router = Router::new()
+        // ... 省略 ...
+    ;
+
+    #[cfg(feature = "webui")]
+    let router = router
+        .route("/ui", get(webui_index_handler))
+        .route("/ui/*path", get(webui_static_handler));
+
+    router
+        .layer(middleware::from_fn_with_state(
+            auth_manager,
+            auth_middleware,
+        ))
+        .with_state(state)
+}
+```
+
+#### Web UIハンドラの条件付きコンパイル
+
+**Before**
+
+```rust
+async fn webui_index_handler() -> impl IntoResponse {
+    crate::webui::serve_index()
+}
+async fn webui_static_handler(Path(path): Path<String>) -> impl IntoResponse {
+    crate::webui::serve_static(&path)
+}
+```
+
+**After**
+
+```rust
+#[cfg(feature = "webui")]
+async fn webui_index_handler() -> impl IntoResponse {
+    crate::webui::serve_index()
+}
+
+#[cfg(feature = "webui")]
+async fn webui_static_handler(Path(path): Path<String>) -> impl IntoResponse {
+    crate::webui::serve_static(&path)
+}
+```
+
+#### router.rs テストの変更
+
+`test_webui_index_endpoint` と `test_webui_static_endpoint` は `webui` feature時のみ有効。
+
+**After**
+
+```rust
+// Test 13: Web UI index endpoint (webui feature only)
+#[cfg(feature = "webui")]
+#[tokio::test]
+async fn test_webui_index_endpoint() {
+    // ... 変更なし ...
+}
+
+// Test 14: Web UI static files endpoint (webui feature only)
+#[cfg(feature = "webui")]
+#[tokio::test]
+async fn test_webui_static_endpoint() {
+    // ... 変更なし ...
+}
+```
+
+### 2.5 src/webui/mod.rs の変更
+
+`src/webui/mod.rs` からAPIの再エクスポートを削除し、静的ファイル配信機能のみを残す。
+
+**Before**
+
+```rust
+pub mod api;
+
+pub use api::*;  // ← 削除
+
+use rust_embed::RustEmbed;
+// ...
+```
+
+**After**
+
+```rust
+// api モジュールは src/api/ に移動したため、ここではインポートしない
+
+use rust_embed::RustEmbed;
+// ...（残りは変更なし）
+```
+
+---
+
+## 3. Dockerfile変更設計
+
+**対応要件**: REQ-106, REQ-114, REQ-115, REQ-116, NFR-101, NFR-102, NFR-103
+
+### 3.1 マルチステージビルドの再設計
+
+APIのみビルドとフルビルドの両方をサポートするため、Dockerfileを以下の構造に変更する。
+
+#### ステージ構成
+
+```
+Stage 1: builder    - Rustバイナリビルド（全パターン共通）
+Stage 2: node-build - フロントエンドビルド（fullのみ使用）
+Stage 3: runtime    - 最終イメージ（全パターン共通）
+```
+
+### 3.2 変更後Dockerfile
+
+```dockerfile
+# ==============================================================================
+# Build arguments
+# ==============================================================================
+ARG CARGO_BUILD_FEATURES=""
+
+# ==============================================================================
+# Stage 1: Build the Rust application
+# ==============================================================================
+FROM rust:1-bookworm AS builder
+
+ARG CARGO_BUILD_FEATURES
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml Cargo.lock ./
+
+# ダミーソースでの依存キャッシュ（featureフラグを考慮）
+RUN mkdir -p src && \
+    echo 'fn main() { println!("Dummy"); }' > src/main.rs && \
+    echo 'pub fn lib() {}' > src/lib.rs && \
+    if [ -n "$CARGO_BUILD_FEATURES" ]; then \
+        cargo build --release --features "$CARGO_BUILD_FEATURES"; \
+    else \
+        cargo build --release --no-default-features; \
+    fi && \
+    cargo clean -p registry-firewall --release && \
+    rm -rf src
+
+COPY src src/
+
+# web/dist はfull buildの場合のみ必要だが、
+# COPYはディレクトリが存在しない場合エラーになるため、
+# 空ディレクトリを用意する（COPY --if-existsはBuildKit v0.14+で使用可能だが互換性のため回避）
+COPY web web/
+
+# featureフラグを使ってビルド
+RUN if [ -n "$CARGO_BUILD_FEATURES" ]; then \
+        cargo build --release --features "$CARGO_BUILD_FEATURES"; \
+    else \
+        cargo build --release --no-default-features; \
+    fi
+
+# ==============================================================================
+# Stage 2: Build the frontend (full build only)
+# ==============================================================================
+FROM node:20-bookworm-slim AS node-build
+
+WORKDIR /app/web
+
+COPY web/package.json web/package-lock.json ./
+
+RUN npm ci
+
+COPY web/ ./
+
+RUN npm run build
+
+# ==============================================================================
+# Stage 3: Create the minimal runtime image
+# ==============================================================================
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl3 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1000 regfw && \
+    useradd --uid 1000 --gid 1000 --shell /bin/bash --create-home regfw
+
+RUN mkdir -p /data/cache /data/db /config && \
+    chown -R regfw:regfw /data /config
+
+COPY --from=builder /app/target/release/registry-firewall /usr/local/bin/registry-firewall
+COPY configs/config.yaml /config/config.yaml
+
+RUN chown regfw:regfw /usr/local/bin/registry-firewall && \
+    chmod +x /usr/local/bin/registry-firewall
+
+USER regfw
+WORKDIR /home/regfw
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+ENV REGISTRY_FIREWALL_CONFIG=/config/config.yaml \
+    RUST_LOG=info
+
+CMD ["registry-firewall", "--config", "/config/config.yaml"]
+```
+
+### 3.3 ビルド引数とfeatureフラグのマッピング
+
+| イメージ種別 | `--build-arg CARGO_BUILD_FEATURES` | cargo buildコマンド |
+|------------|-------------------------------------|-------------------|
+| APIのみ（デフォルト）| `""` （空文字列） | `cargo build --release --no-default-features` |
+| GUI付き（full） | `"webui"` | `cargo build --release --features "webui"` |
+
+#### 設計根拠
+
+- `CARGO_BUILD_FEATURES=""` をデフォルトにすることで、`--no-default-features` が適用される（REQ-102）
+- `web/dist/` のコピーは常に行われるが、`webui` feature無効時はRustコードがそれを参照しないため、ビルド成果物に含まれない
+- APIのみイメージは `web/dist/` 内容を埋め込まないため、バイナリサイズが小さくなる（NFR-101, NFR-103）
+
+### 3.4 web/dist ディレクトリの扱い
+
+`COPY web web/` は `web/dist/` が存在しない場合でもエラーにならない（ディレクトリ全体をコピーするため）。ただし `webui` feature有効時は `web/dist/` が存在する必要があるため、full buildのDockerfileでは前段のnode-buildステージからコピーする。
+
+**APIのみビルドのDockerfile（docker/Dockerfile）**: `web/dist/` 不要。`COPY web web/` を削除可能。
+
+**GUI付きビルドのDockerfile（docker/Dockerfile.full）**: node-buildステージを使用。
+
+#### 設計決定: Dockerfile分割 vs 単一Dockerfile
+
+単一のDockerfileで両方をサポートするとbuild-argによる条件分岐が複雑になる。以下の設計を採用する:
+
+| ファイル | 用途 |
+|---------|------|
+| `deployments/docker/Dockerfile` | APIのみビルド（web/ コピーなし、`--no-default-features`） |
+| `deployments/docker/Dockerfile.full` | GUI付きビルド（node-buildステージあり、`--features webui`） |
+
+---
+
+## 4. release.yml変更設計
+
+**対応要件**: REQ-110, REQ-111, REQ-112, REQ-113, REQ-115, REQ-124, NFR-104, NFR-105
+
+### 4.1 ジョブ構成
+
+```
+test
+├── generate-swagger (depends: test)
+├── build-docker-api (depends: test)           ← APIのみ
+├── build-docker-full (depends: test)          ← GUI付き
+└── create-release (depends: test, generate-swagger, build-docker-api, build-docker-full)
+```
+
+`build-docker-api` と `build-docker-full` は並列実行される（NFR-105）。
+
+### 4.2 タグ命名規則
+
+#### APIのみイメージのタグ（現在の `latest` の置き換え）
+
+| リリース種別 | タグ |
+|------------|------|
+| 安定版 `vX.Y.Z` | `latest`, `X.Y.Z`, `X.Y`, `X` |
+| プレリリース `vX.Y.Z-alpha` | `X.Y.Z-alpha` のみ（`latest` なし） |
+
+#### GUI付きイメージのタグ
+
+| リリース種別 | タグ |
+|------------|------|
+| 安定版 `vX.Y.Z` | `latest-full`, `X.Y.Z-full`, `X.Y-full`, `X-full` |
+| プレリリース `vX.Y.Z-alpha` | `X.Y.Z-alpha-full` のみ（`latest-full` なし） |
+
+**注意**: `docker/metadata-action` の `type=semver` はハイフンサフィックスを自動でプレリリースと判定し `latest` タグを付与しない（REQ-113）。
+
+### 4.3 変更後 release.yml（抜粋）
+
+#### build-docker-api ジョブ
+
+```yaml
+build-docker-api:
+  name: Build and Push Docker Image (API only)
+  runs-on: ubuntu-latest
+  needs: test
+  permissions:
+    contents: read
+    packages: write
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata for API-only image
+      id: meta-api
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}},enable=${{ needs.test.outputs.is_prerelease == 'false' }}
+          type=semver,pattern={{major}},enable=${{ needs.test.outputs.is_prerelease == 'false' }}
+          type=raw,value=latest,enable=${{ needs.test.outputs.is_prerelease == 'false' }}
+
+    - name: Build and push API-only Docker image
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: deployments/docker/Dockerfile
+        push: true
+        tags: ${{ steps.meta-api.outputs.tags }}
+        labels: ${{ steps.meta-api.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/amd64,linux/arm64
+```
+
+#### build-docker-full ジョブ
+
+```yaml
+build-docker-full:
+  name: Build and Push Docker Image (Full with Web UI)
+  runs-on: ubuntu-latest
+  needs: test
+  permissions:
+    contents: read
+    packages: write
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata for full image
+      id: meta-full
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=semver,pattern={{version}}-full
+          type=semver,pattern={{major}}.{{minor}}-full,enable=${{ needs.test.outputs.is_prerelease == 'false' }}
+          type=semver,pattern={{major}}-full,enable=${{ needs.test.outputs.is_prerelease == 'false' }}
+          type=raw,value=latest-full,enable=${{ needs.test.outputs.is_prerelease == 'false' }}
+
+    - name: Build and push full Docker image
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: deployments/docker/Dockerfile.full
+        push: true
+        tags: ${{ steps.meta-full.outputs.tags }}
+        labels: ${{ steps.meta-full.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/amd64,linux/arm64
+```
+
+#### generate-swagger ジョブ
+
+```yaml
+generate-swagger:
+  name: Generate swagger.json
+  runs-on: ubuntu-latest
+  needs: test
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Generate swagger.json
+      run: cargo run --features swagger-gen -- --generate-swagger
+
+    - name: Upload swagger.json as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: swagger-json
+        path: swagger.json
+```
+
+#### create-release ジョブの変更
+
+```yaml
+create-release:
+  name: Create GitHub Release
+  runs-on: ubuntu-latest
+  needs: [test, generate-swagger, build-docker-api, build-docker-full]
+  permissions:
+    contents: write
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Download swagger.json
+      uses: actions/download-artifact@v4
+      with:
+        name: swagger-json
+
+    - name: Generate release notes
+      run: |
+        # ... 既存のリリースノート生成ロジック（変更なし） ...
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        prerelease: ${{ needs.test.outputs.is_prerelease }}
+        body_path: release-notes.md
+        files: swagger.json  # ← swagger.json をアセットに添付
+```
+
+---
+
+## 5. utoipa統合設計
+
+**対応要件**: REQ-120, REQ-121, REQ-122, REQ-123, REQ-125, REQ-126, REQ-127, REQ-128, REQ-129
+
+### 5.1 アノテーション対象エンドポイント一覧
+
+以下のすべての `/api/*` エンドポイントに `#[utoipa::path]` を付与する（REQ-121）。
+
+| ハンドラ関数 | メソッド | パス | 説明 |
+|-------------|---------|------|------|
+| `api_dashboard_handler` | GET | `/api/dashboard` | ダッシュボード統計取得 |
+| `api_blocks_handler` | GET | `/api/blocks` | ブロックログ一覧取得 |
+| `api_security_sources_handler` | GET | `/api/security-sources` | セキュリティソース一覧 |
+| `api_trigger_sync_handler` | POST | `/api/security-sources/{name}/sync` | 同期トリガー |
+| `api_cache_stats_handler` | GET | `/api/cache/stats` | キャッシュ統計取得 |
+| `api_cache_clear_handler` | DELETE | `/api/cache` | キャッシュクリア |
+| `api_list_rules_handler` | GET | `/api/rules` | カスタムルール一覧 |
+| `api_create_rule_handler` | POST | `/api/rules` | カスタムルール作成 |
+| `api_get_rule_handler` | GET | `/api/rules/{id}` | カスタムルール取得 |
+| `api_update_rule_handler` | PUT | `/api/rules/{id}` | カスタムルール更新 |
+| `api_delete_rule_handler` | DELETE | `/api/rules/{id}` | カスタムルール削除 |
+| `api_list_tokens_handler` | GET | `/api/tokens` | トークン一覧 |
+| `api_create_token_handler` | POST | `/api/tokens` | トークン作成 |
+| `api_delete_token_handler` | DELETE | `/api/tokens/{id}` | トークン削除 |
+
+### 5.2 ToSchema derive対象の構造体一覧
+
+以下の構造体に `ToSchema` を追加する（REQ-122）。
+
+`src/api/types.rs`（移動後）:
+- `DashboardStats`
+- `SecuritySourceSummary`
+- `BlockLogsQuery`
+- `BlockLogsResponse`
+- `BlockLogEntry`
+- `SecuritySourcesResponse`
+- `SecuritySourceInfo`
+- `SyncTriggerResponse`
+- `CacheStatsResponse`
+- `CacheClearResponse`
+- `RulesResponse`
+- `TokensResponse`
+- `TokenInfo`
+- `CreateTokenRequest`
+- `CreateTokenResponse`
+- `MessageResponse`
+- `ErrorResponse`
+
+`src/server/router.rs`:
+- `CreateTokenApiRequest`
+
+`src/models/`:
+- `CustomRule`（既存モデル）
+
+### 5.3 utoipa アノテーション例
+
+```rust
+// src/server/router.rs
+
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    get,
+    path = "/api/dashboard",
+    responses(
+        (status = 200, description = "Dashboard statistics", body = DashboardStats),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+    ),
+    security(
+        ("bearer_token" = []),
+        ("basic_auth" = []),
+    ),
+    tag = "dashboard"
+))]
+async fn api_dashboard_handler<D: Database + 'static>(
+    State(state): State<AppState<D>>,
+) -> impl IntoResponse {
+    // ...
+}
+```
+
+`#[cfg_attr(feature = "swagger-gen", utoipa::path(...))]` を使用することで、`swagger-gen` feature無効時はアノテーションがコンパイル対象外になる。
+
+### 5.4 ApiDoc 構造体定義
+
+`src/server/router.rs` または `src/api/openapi.rs`（新規）に配置する。
+
+```rust
+#[cfg(feature = "swagger-gen")]
+use utoipa::OpenApi;
+
+#[cfg(feature = "swagger-gen")]
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "registry-firewall API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "A unified registry proxy that protects development environments from software supply chain attacks",
+    ),
+    paths(
+        api_dashboard_handler,
+        api_blocks_handler,
+        api_security_sources_handler,
+        api_trigger_sync_handler,
+        api_cache_stats_handler,
+        api_cache_clear_handler,
+        api_list_rules_handler,
+        api_create_rule_handler,
+        api_get_rule_handler,
+        api_update_rule_handler,
+        api_delete_rule_handler,
+        api_list_tokens_handler,
+        api_create_token_handler,
+        api_delete_token_handler,
+    ),
+    components(
+        schemas(
+            DashboardStats, SecuritySourceSummary, BlockLogsQuery, BlockLogsResponse,
+            BlockLogEntry, SecuritySourcesResponse, SecuritySourceInfo, SyncTriggerResponse,
+            CacheStatsResponse, CacheClearResponse, RulesResponse, TokensResponse,
+            TokenInfo, CreateTokenRequest, CreateTokenResponse, MessageResponse, ErrorResponse,
+            CustomRule, CreateTokenApiRequest,
+        )
+    ),
+    modifiers(&SecurityAddon),
+    tags(
+        (name = "dashboard", description = "Dashboard statistics"),
+        (name = "blocks", description = "Block log management"),
+        (name = "security-sources", description = "Security source management"),
+        (name = "cache", description = "Cache management"),
+        (name = "rules", description = "Custom block rule management"),
+        (name = "tokens", description = "API token management"),
+    )
+)]
+pub struct ApiDoc;
+
+/// Security schemes modifier
+#[cfg(feature = "swagger-gen")]
+struct SecurityAddon;
+
+#[cfg(feature = "swagger-gen")]
+impl utoipa::Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi.components.get_or_insert_with(Default::default);
+        components.add_security_scheme(
+            "bearer_token",
+            utoipa::openapi::security::SecurityScheme::Http(
+                utoipa::openapi::security::HttpBuilder::new()
+                    .scheme(utoipa::openapi::security::HttpAuthScheme::Bearer)
+                    .bearer_format("token")
+                    .build(),
+            ),
+        );
+        components.add_security_scheme(
+            "basic_auth",
+            utoipa::openapi::security::SecurityScheme::Http(
+                utoipa::openapi::security::HttpBuilder::new()
+                    .scheme(utoipa::openapi::security::HttpAuthScheme::Basic)
+                    .build(),
+            ),
+        );
+    }
+}
+```
+
+**対応要件**: REQ-125（OpenAPI 3.0準拠）, REQ-126（タイトル・バージョン・説明文）, REQ-129（BearerToken・Basic認証のsecuritySchemes）
+
+### 5.5 --generate-swagger CLIオプション
+
+`src/main.rs` に `--generate-swagger` オプションを追加する。
+
+#### Argsへの追加
+
+```rust
+#[derive(Parser, Debug)]
+#[command(name = "registry-firewall")]
+struct Args {
+    /// Path to the configuration file
+    #[arg(short, long, env = "REGISTRY_FIREWALL_CONFIG")]
+    config: Option<String>,
+
+    /// Generate OpenAPI specification (swagger.json) and exit
+    #[cfg(feature = "swagger-gen")]
+    #[arg(long)]
+    generate_swagger: bool,
+}
+```
+
+#### main()への追加
+
+```rust
+#[cfg(feature = "swagger-gen")]
+if args.generate_swagger {
+    use registry_firewall::server::router::ApiDoc;
+    use utoipa::OpenApi;
+    let spec = ApiDoc::openapi().to_pretty_json().expect("Failed to serialize OpenAPI spec");
+    std::fs::write("swagger.json", spec).expect("Failed to write swagger.json");
+    eprintln!("swagger.json generated successfully");
+    return Ok(());
+}
+```
+
+**対応要件**: REQ-123（`--generate-swagger` コマンド実行時にswagger.jsonを出力）
+
+### 5.6 Swagger UI エンドポイント
+
+`webui` featureと `swagger-gen` featureが両方有効の場合、`/api/swagger-ui` でインタラクティブなSwagger UIを提供する。
+
+```rust
+// src/server/router.rs build_router() 内
+
+#[cfg(all(feature = "webui", feature = "swagger-gen"))]
+let router = router.merge(
+    utoipa_swagger_ui::SwaggerUi::new("/api/swagger-ui")
+        .url("/api/openapi.json", ApiDoc::openapi())
+);
+```
+
+**対応要件**: REQ-127（webui feature有効時にSwagger UI提供）, REQ-128（webui feature無効時は提供不要）
+
+---
+
+## 6. CI (ci.yml) 変更設計
+
+**対応要件**: REQ-104（`--no-default-features`でのビルド・テスト）
+
+### 6.1 追加ジョブ
+
+既存の `test` ジョブ（`--all-features`）に加えて、`test-no-default-features` ジョブを追加する。
+
+```yaml
+test-no-default-features:
+  name: Test (no default features)
+  runs-on: ubuntu-latest
+  needs: changes
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Build without default features
+      run: cargo build --no-default-features
+
+    - name: Run tests without default features
+      run: cargo test --no-default-features
+```
+
+### 6.2 既存ジョブの維持
+
+既存の `test`, `check`, `clippy` ジョブは `--all-features` を維持する（制約事項）。
+
+#### check ジョブへの追加
+
+`--no-default-features` ビルドのチェックを `check` ジョブの既存ステップに追加することも可能だが、CI分離性を高めるため独立ジョブとする。
+
+### 6.3 docker-build ジョブの変更
+
+両方のDockerfileをビルドチェックする。
+
+```yaml
+docker-build:
+  name: Docker Build Check
+  runs-on: ubuntu-latest
+  needs: changes
+  if: ${{ needs.changes.outputs.docker == 'true' }}
+  permissions:
+    contents: read
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build API-only Docker image (no push)
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: deployments/docker/Dockerfile
+        push: false
+        tags: registry-firewall:ci-check-api
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Build full Docker image (no push)
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: deployments/docker/Dockerfile.full
+        push: false
+        tags: registry-firewall:ci-check-full
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+```
+
+---
+
+## 7. ファイル変更一覧
+
+| ファイル | 変更種別 | 変更内容 |
+|---------|---------|---------|
+| `Cargo.toml` | 変更 | `[features]`セクション追加、`rust-embed`・`mime_guess`をoptional化、`utoipa`・`utoipa-axum`・`utoipa-swagger-ui`追加 |
+| `src/lib.rs` | 変更 | `webui`モジュールを`cfg(feature = "webui")`で条件付き、`api`モジュール追加 |
+| `src/api/mod.rs` | 新規 | `src/webui/api.rs`から移動、re-export |
+| `src/api/types.rs` | 新規 | 型定義（DashboardStats等）+ `ToSchema` derive追加 |
+| `src/api/handlers.rs` | 新規 | APIビジネスロジック関数 |
+| `src/api/openapi.rs` | 新規 | `ApiDoc`構造体、`SecurityAddon`（`swagger-gen` feature条件付き） |
+| `src/webui/mod.rs` | 変更 | `pub mod api;`と`pub use api::*;`を削除 |
+| `src/server/router.rs` | 変更 | インポートパス変更、Web UIルート・ハンドラを`cfg(feature = "webui")`で条件付き、`#[utoipa::path]`アノテーション追加 |
+| `src/main.rs` | 変更 | `--generate-swagger` CLIオプション追加 |
+| `deployments/docker/Dockerfile` | 変更 | `web/`コピーを削除、`--no-default-features`でビルド |
+| `deployments/docker/Dockerfile.full` | 新規 | node-buildステージ追加、`--features webui`でビルド |
+| `.github/workflows/release.yml` | 変更 | `build-docker-api`・`build-docker-full`・`generate-swagger`ジョブ追加 |
+| `.github/workflows/ci.yml` | 変更 | `test-no-default-features`ジョブ追加、`docker-build`ジョブに`Dockerfile.full`追加 |
+
+---
+
+## 8. 設計上の制約と決定事項
+
+### 8.1 `webui::api` → `api` への移動について
+
+`src/webui/api.rs` に定義された型（`DashboardStats`等）は `src/server/router.rs` から直接使用されている。`webui` featureの条件付きコンパイルを適切に機能させるには、これらの型をfeatureに依存しない独立モジュールに移動する必要がある。
+
+既存のコードは `crate::webui::api::DashboardStats` のような参照を持つ可能性があるため、移動後は `src/webui/mod.rs` からの再エクスポートを一時的に維持することも可能だが、モジュール構造の明確化のため直接参照に変更する。
+
+### 8.2 NFR-106（後方互換性）の取り扱い
+
+`latest` タグのセマンティクスが変わる（GUI付き → APIのみ）ため、リリース時のCHANGELOGへの記載が必要。本設計書はCHANGELOGの内容そのものは定義しないが、実装タスクにCHANGELOG更新を含める。
+
+### 8.3 swagger.json のサーバー定義
+
+REQ-129（NFR-109）に従い、swagger.json のサーバー定義には本番環境の内部ホスト名を含めない。
+
+```rust
+// SecurityAddon に加えて ServerAddon も実装
+impl utoipa::Modify for ServerAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        openapi.servers = Some(vec![
+            utoipa::openapi::ServerBuilder::new()
+                .url("{scheme}://{host}:{port}")
+                .description(Some("registry-firewall instance"))
+                .build(),
+        ]);
+    }
+}
+```
+
+---
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 | 作成者 |
+|-----------|------|----------|--------|
+| 1.0 | 2026-03-18 | 初版作成 | - |

--- a/docs/sdd/requirements-dual-docker.md
+++ b/docs/sdd/requirements-dual-docker.md
@@ -41,7 +41,7 @@
 - **REQ-103** [State-driven] `webui` featureが無効化された状態でビルドされた場合、`/ui`および`/ui/*`エンドポイントはルーターに登録されず、リクエストは404を返さなければならない
 - **REQ-104** [Event-driven] `--no-default-features`フラグを指定してビルドした時、システムはすべてのAPIエンドポイント（`/api/*`）を正常に提供しなければならない
 - **REQ-105** [State-driven] `webui` featureが無効化された状態でビルドされた場合、`webui`モジュール（`src/webui/`）のコードはコンパイルの対象外となり、コンパイル時間を削減しなければならない
-- **REQ-106** [Ubiquitous] DockerfileはARGビルド引数`CARGO_BUILD_FEATURES`を受け取り、`""`（空文字列、デフォルト）または`"webui"`を切り替えて使用できなければならない
+- **REQ-106** [Ubiquitous] APIのみビルド用の`deployments/docker/Dockerfile`は`--no-default-features`でビルドし、GUI付きビルド用の`deployments/docker/Dockerfile.full`は`--features webui`およびNode.jsフロントエンドビルドステージを含めなければならない
 - **REQ-107** [Event-driven] APIのみイメージ（`latest`、`X.Y.Z`）がビルドされた時、タグには`-full`サフィックスが付かないデフォルトタグが使用されなければならない
 
 #### 受入テスト
@@ -157,7 +157,7 @@ gh release view v1.2.3 --json assets | jq '.[].name' | grep swagger.json
 
 ### 後方互換性
 
-- **NFR-106** [Ubiquitous] 既存の`latest`タグのセマンティクスは変更してはならない（現在`latest`は全機能を含むが、本変更後は`latest`はAPIのみに変わる）。この変更はCHANGELOGで明示的に告知されなければならない
+- **NFR-106** [Ubiquitous] `latest`タグのセマンティクスがGUI付きからAPIのみに変わることは、破壊的変更としてCHANGELOGおよびリリースノートで明示的に告知されなければならない
 - **NFR-107** [Ubiquitous] `webui` featureが有効化された状態でビルドした場合、既存の`/ui/*`エンドポイントおよびすべての`/api/*`エンドポイントの動作が変わってはならない
 
 ### セキュリティ

--- a/docs/sdd/requirements-dual-docker.md
+++ b/docs/sdd/requirements-dual-docker.md
@@ -46,7 +46,7 @@
 
 #### 受入テスト
 
-```
+```shell
 # featureなしビルドのテスト
 cargo build --no-default-features
 # → webui関連のコンパイルエラーがないこと
@@ -83,7 +83,7 @@ curl -s http://localhost:8080/api/dashboard
 
 #### 受入テスト
 
-```
+```shell
 # GHCRでのイメージタグ確認（v1.2.3リリース時）
 docker pull ghcr.io/windschord/registry-firewall:latest       # APIのみ
 docker pull ghcr.io/windschord/registry-firewall:1.2.3        # APIのみ
@@ -119,7 +119,7 @@ curl -s http://localhost:8080/ui
 
 #### 受入テスト
 
-```
+```shell
 # swagger.json の生成確認
 cargo run --features swagger-gen -- --generate-swagger
 ls -la swagger.json

--- a/docs/sdd/requirements-dual-docker.md
+++ b/docs/sdd/requirements-dual-docker.md
@@ -1,0 +1,202 @@
+# 要件定義書: Dual Docker Image Release + Swagger自動生成
+
+## 概要
+
+本ドキュメントは、registry-firewallに「デュアルDockerイメージリリース」と「OpenAPI仕様の自動生成」機能を追加するための要件を定義する。EARS記法（Easy Approach to Requirements Syntax）を用いて記述する。
+
+### 背景
+
+現在のリリースパイプラインは単一のDockerイメージのみをビルドしており、Web UIを含む全機能が常に含まれる。運用環境によってはWeb UIが不要（CI/CDパイプライン、ヘッドレスサーバー等）であり、その場合でもrust-embedによるUIアセット埋め込みが発生する。また、API仕様をSwagger/OpenAPI形式で提供する手段がなく、外部システムとのインテグレーション時に仕様を手動で参照する必要がある。
+
+### 関連ドキュメント
+
+- 既存要件: `docs/requirements.md`（REQ-001〜REQ-045、NFR-001〜NFR-024）
+- 技術設計: `docs/design.md`
+- タスク計画: `docs/tasks.md`
+
+### 現在の実装状態（起点）
+
+| コンポーネント | 現状 |
+|--------------|------|
+| Cargo.toml | `features`セクション未定義。`rust-embed`と`mime_guess`は通常依存 |
+| Dockerfile | マルチステージビルド（rust:1-bookworm → debian:bookworm-slim）。`web/dist`をコピー |
+| release.yml | 単一イメージのビルド・プッシュ。GHCR使用。linux/amd64+arm64 |
+| src/webui/mod.rs | `RustEmbed`で`web/dist`を埋め込み |
+| src/server/router.rs | `/ui`、`/ui/*path`ルートがハードコード |
+
+---
+
+## ユーザーストーリー
+
+### ストーリーA: 軽量APIのみイメージ
+
+**私は** 運用者として
+**〜したい** Web UIが不要な環境（CI/CD、ヘッドレスサーバー）向けに軽量なDockerイメージを使いたい
+**なぜなら** UIアセットの埋め込みによるバイナリ肥大化を避け、攻撃対象領域を最小化したいから
+
+#### 受入基準（EARS記法）
+
+- **REQ-101** [Ubiquitous] Cargo.tomlは`[features]`セクションを持ち、`default = ["webui"]`と`webui = ["rust-embed", "mime_guess"]`を定義しなければならない
+- **REQ-102** [State-driven] `webui` featureが無効化された状態でビルドされた場合、バイナリはrust-embedおよびmime_guessの依存を含んではならない
+- **REQ-103** [State-driven] `webui` featureが無効化された状態でビルドされた場合、`/ui`および`/ui/*`エンドポイントはルーターに登録されず、リクエストは404を返さなければならない
+- **REQ-104** [Event-driven] `--no-default-features`フラグを指定してビルドした時、システムはすべてのAPIエンドポイント（`/api/*`）を正常に提供しなければならない
+- **REQ-105** [State-driven] `webui` featureが無効化された状態でビルドされた場合、`webui`モジュール（`src/webui/`）のコードはコンパイルの対象外となり、コンパイル時間を削減しなければならない
+- **REQ-106** [Ubiquitous] DockerfileはARGビルド引数`CARGO_BUILD_FEATURES`を受け取り、`""`（空文字列、デフォルト）または`"webui"`を切り替えて使用できなければならない
+- **REQ-107** [Event-driven] APIのみイメージ（`latest`、`X.Y.Z`）がビルドされた時、タグには`-full`サフィックスが付かないデフォルトタグが使用されなければならない
+
+#### 受入テスト
+
+```
+# featureなしビルドのテスト
+cargo build --no-default-features
+# → webui関連のコンパイルエラーがないこと
+
+cargo test --no-default-features
+# → すべてのテストがパスすること
+
+# /ui エンドポイントが存在しないことの確認
+curl -s http://localhost:8080/ui
+# → HTTP 404が返ること
+
+# /api エンドポイントが動作することの確認
+curl -s http://localhost:8080/api/dashboard
+# → HTTP 200が返ること
+```
+
+---
+
+### ストーリーB: フル機能GUI付きイメージ
+
+**私は** 管理者として
+**〜したい** Web UIでブロック状況を視覚的に確認・管理したい場合にGUI付きイメージを使いたい
+**なぜなら** CLIを使わず直感的にシステム状態を把握・操作したいから
+
+#### 受入基準（EARS記法）
+
+- **REQ-110** [Ubiquitous] GitHub Actionsリリースワークフローは、同一リリースで2種類のDockerイメージをビルドしてGHCRにプッシュしなければならない
+- **REQ-111** [Event-driven] リリースタグ`v X.Y.Z`がプッシュされた時、APIのみイメージは`latest`および`X.Y.Z`タグでGHCRにプッシュされなければならない
+- **REQ-112** [Event-driven] リリースタグ`v X.Y.Z`がプッシュされた時、GUI付きイメージは`latest-full`および`X.Y.Z-full`タグでGHCRにプッシュされなければならない
+- **REQ-113** [Event-driven] プレリリースタグ（`v X.Y.Z-alpha`等、ハイフンを含むタグ）がプッシュされた時、`latest`および`latest-full`タグは付与されず、バージョンタグのみ付与されなければならない
+- **REQ-114** [State-driven] `webui` featureが有効化された状態でビルドされた場合、`/ui`エンドポイントは`web/dist`の組み込みアセットを正常に配信しなければならない
+- **REQ-115** [Ubiquitous] 両イメージは`linux/amd64`および`linux/arm64`の両プラットフォーム向けにビルドされなければならない
+- **REQ-116** [Ubiquitous] 両イメージのDockerfileは同一のベースイメージ（`debian:bookworm-slim`）を使用しなければならない
+
+#### 受入テスト
+
+```
+# GHCRでのイメージタグ確認（v1.2.3リリース時）
+docker pull ghcr.io/windschord/registry-firewall:latest       # APIのみ
+docker pull ghcr.io/windschord/registry-firewall:1.2.3        # APIのみ
+docker pull ghcr.io/windschord/registry-firewall:latest-full  # GUI付き
+docker pull ghcr.io/windschord/registry-firewall:1.2.3-full   # GUI付き
+
+# full イメージでの /ui エンドポイント確認
+docker run -p 8080:8080 ghcr.io/windschord/registry-firewall:latest-full
+curl -s http://localhost:8080/ui
+# → HTTP 200が返ること（もしくはindex.htmlが返ること）
+```
+
+---
+
+### ストーリーC: OpenAPI仕様の自動生成
+
+**私は** 開発者/インテグレーターとして
+**〜したい** APIの仕様書（Swagger）をリリースごとに最新状態で参照したい
+**なぜなら** 外部システムとの連携実装時に手動でエンドポイントを調査する手間を省きたいから
+
+#### 受入基準（EARS記法）
+
+- **REQ-120** [Ubiquitous] Cargo.tomlは`utoipa`クレートを依存関係に含み、axum向けの統合（`utoipa-axum`）を使用しなければならない
+- **REQ-121** [Ubiquitous] すべての管理APIエンドポイント（`/api/*`）はutoipaの`#[utoipa::path]`アトリビュートでアノテーションされなければならない
+- **REQ-122** [Ubiquitous] リクエスト・レスポンスのすべての構造体は`ToSchema`トレイトをderiveしなければならない
+- **REQ-123** [Event-driven] `cargo run --features swagger-gen -- --generate-swagger`コマンドが実行された時、システムは`swagger.json`をカレントディレクトリに出力しなければならない
+- **REQ-124** [Event-driven] リリースタグがプッシュされた時、GitHub Actionsワークフローは`swagger.json`を自動生成し、GitHubリリースのアセットとして添付しなければならない
+- **REQ-125** [Ubiquitous] 生成された`swagger.json`はOpenAPI 3.0仕様に準拠しなければならない
+- **REQ-126** [Ubiquitous] `swagger.json`にはAPIのタイトル、バージョン（Cargo.tomlのバージョンと一致）、説明文を含めなければならない
+- **REQ-127** [State-driven] `webui` featureが有効化されている場合、`/api/swagger-ui`エンドポイントにアクセスすると、インタラクティブなSwagger UIが表示されなければならない
+- **REQ-128** [State-driven] `webui` featureが無効化されている場合、Swagger UIエンドポイントは提供されなくてよい（swagger.jsonのリリース添付は常に行う）
+- **REQ-129** [Ubiquitous] 生成された`swagger.json`はすべての認証方式（BearerToken、Basic認証）をsecuritySchemesとして記述しなければならない
+
+#### 受入テスト
+
+```
+# swagger.json の生成確認
+cargo run --features swagger-gen -- --generate-swagger
+ls -la swagger.json
+# → ファイルが生成されること
+
+# OpenAPI 3.0 検証
+npx @redocly/cli lint swagger.json
+# → バリデーションエラーがないこと
+
+# バージョン一致確認
+CARGO_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+SWAGGER_VERSION=$(jq -r '.info.version' swagger.json)
+test "$CARGO_VERSION" = "$SWAGGER_VERSION"
+# → バージョンが一致すること
+
+# GitHubリリースアセット確認（リリース後）
+gh release view v1.2.3 --json assets | jq '.[].name' | grep swagger.json
+# → swagger.json がアセットに含まれること
+```
+
+---
+
+## 非機能要件
+
+### イメージサイズ
+
+- **NFR-101** [Ubiquitous] APIのみイメージ（`latest`）の圧縮サイズは80MB以下でなければならない
+- **NFR-102** [Ubiquitous] GUI付きイメージ（`latest-full`）の圧縮サイズは120MB以下でなければならない
+- **NFR-103** [Ubiquitous] APIのみイメージはGUI付きイメージと比較して、少なくとも20%小さくなければならない
+
+### ビルド時間
+
+- **NFR-104** [Ubiquitous] GitHub Actionsキャッシュ（`Swatinem/rust-cache`）を利用した場合、各イメージの増分ビルド時間は10分以内でなければならない
+- **NFR-105** [Ubiquitous] APIのみイメージのビルドはGUI付きイメージのビルドと並列実行可能でなければならない（GitHub Actionsの並列ジョブとして）
+
+### 後方互換性
+
+- **NFR-106** [Ubiquitous] 既存の`latest`タグのセマンティクスは変更してはならない（現在`latest`は全機能を含むが、本変更後は`latest`はAPIのみに変わる）。この変更はCHANGELOGで明示的に告知されなければならない
+- **NFR-107** [Ubiquitous] `webui` featureが有効化された状態でビルドした場合、既存の`/ui/*`エンドポイントおよびすべての`/api/*`エンドポイントの動作が変わってはならない
+
+### セキュリティ
+
+- **NFR-108** [Ubiquitous] APIのみイメージはrust-embedによるファイルシステムアクセスのコードパスを含まないため、ファイル読み取り関連のCVEリスクが低減されなければならない
+- **NFR-109** [Ubiquitous] swagger.jsonは本番環境の内部ホスト名やIPアドレスを含んではならない（サーバー定義にはプレースホルダーを使用する）
+
+---
+
+## 制約事項
+
+| 制約 | 内容 |
+|-----|------|
+| 既存テストの維持 | 既存の`cargo test --all-features`がすべてパスし続けること |
+| Cargo.tomlの変更 | `rust-embed`と`mime_guess`を`[dependencies]`から`[dev-dependencies]`相当ではなくfeature依存に移動する |
+| GHCR命名規則 | タグ命名はセマンティックバージョニングに従い、既存のGHCR URLパターンを維持する |
+| CI/CDの変更最小化 | release.ymlへの変更はdual image buildのために最小限の追加にとどめる |
+| utoipa統合 | `utoipa-axum`を使用し、既存のaxumルーター構造への変更を最小限にする |
+
+---
+
+## 用語集
+
+| 用語 | 定義 |
+|------|------|
+| Cargo feature | Rustの条件付きコンパイル機構。`Cargo.toml`の`[features]`セクションで定義する |
+| GHCR | GitHub Container Registry。GitHubが提供するコンテナイメージレジストリ |
+| utoipa | Rust向けOpenAPI仕様自動生成クレート。マクロベースでエンドポイントを注釈する |
+| OpenAPI | RESTful APIの仕様記述標準（旧Swagger）。バージョン3.0を使用 |
+| swagger.json | OpenAPI仕様をJSON形式で出力したファイル |
+| APIのみイメージ | `webui` featureなし（`--no-default-features`）でビルドされたDockerイメージ |
+| GUI付きイメージ | `webui` feature有効（デフォルト）でビルドされたDockerイメージ |
+| `-full` サフィックス | GUI付きDockerイメージを示すタグの接尾辞（例: `latest-full`、`1.2.3-full`） |
+| `swagger-gen` feature | swagger.json生成用コマンドラインオプションを有効にするCargo feature |
+
+---
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 | 作成者 |
+|-----------|------|----------|--------|
+| 1.0 | 2026-03-18 | 初版作成（Dual Docker Image Release + Swagger自動生成） | - |

--- a/docs/sdd/tasks-dual-docker.md
+++ b/docs/sdd/tasks-dual-docker.md
@@ -1,0 +1,1202 @@
+# タスク計画書: Dual Docker Image Release + Swagger自動生成
+
+## 概要
+
+本ドキュメントは、設計書 `docs/sdd/design-dual-docker.md` に基づき、「デュアルDockerイメージリリース」と「OpenAPI仕様の自動生成」機能の実装タスクを定義する。
+
+### トレーサビリティ
+
+- 要件定義書: `docs/sdd/requirements-dual-docker.md`
+- 技術設計書: `docs/sdd/design-dual-docker.md`
+
+---
+
+## 依存関係グラフ
+
+```
+Phase 1 (モジュール再編成)
+├── TASK-001: src/webui/api.rs → src/api/ 移動
+├── TASK-002: src/server/router.rs インポートパス変更
+└── TASK-003: src/lib.rs 更新
+        ↓ (Phase 1完了後)
+Phase 2 (Cargo features導入)
+├── TASK-004: Cargo.toml features定義
+├── TASK-005: src/lib.rs cfg(feature)追加
+└── TASK-006: src/server/router.rs 条件付きルート・ハンドラ
+        ↓ (Phase 2完了後)
+  ┌─────────────────────────────────────────────┐
+  ↓                                             ↓
+Phase 3 (Dockerfile変更)              Phase 4 (utoipa統合)
+├── TASK-007: Dockerfile変更           ├── TASK-009: utoipa依存追加
+└── TASK-008: Dockerfile.full新規      ├── TASK-010: ToSchema derive追加
+                                       ├── TASK-011: #[utoipa::path]アノテーション
+                                       ├── TASK-012: ApiDoc構造体実装
+                                       └── TASK-013: --generate-swagger CLIオプション
+        ↓ (Phase 3, 4完了後)
+Phase 5 (CI/CD変更)
+├── TASK-014: ci.yml test-no-default-features追加
+├── TASK-015: ci.yml docker-buildジョブ拡張
+├── TASK-016: release.yml デュアルイメージビルド
+└── TASK-017: release.yml swagger.json生成・添付
+```
+
+### フェーズ間の並列実行
+
+Phase 3とPhase 4は互いに独立しており、Phase 2完了後に並列実行が可能。
+
+---
+
+## Phase 1: モジュール再編成
+
+**目的**: `src/webui/api.rs` の内容をfeature非依存の `src/api/` モジュールに移動し、後続のcfg(feature)適用を可能にする。
+
+**前提**: なし（最初に実施）
+
+**完了基準**: `cargo test --all-features` が全テストパス
+
+---
+
+### TASK-001: src/api/ モジュールの新規作成
+
+**対応要件**: REQ-103, REQ-104, REQ-105
+
+**対象ファイル**:
+- `src/api/mod.rs` （新規作成）
+- `src/api/types.rs` （新規作成、`src/webui/api.rs` から型定義を移動）
+- `src/api/handlers.rs` （新規作成、`src/webui/api.rs` からハンドラロジックを移動）
+
+#### Red（テスト作成）
+
+`src/api/types.rs` に存在すべき型（`DashboardStats`等）のコンパイルテストを作成する。
+
+```rust
+// src/api/mod.rs に追加するテスト
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TASK-001-T1: DashboardStats がデフォルト値で生成できること
+    #[test]
+    fn test_dashboard_stats_default() {
+        let stats = DashboardStats::default();
+        assert_eq!(stats.total_requests, 0);
+        assert_eq!(stats.blocked_requests, 0);
+    }
+
+    // TASK-001-T2: BlockLogsQuery がデシリアライズできること
+    #[test]
+    fn test_block_logs_query_deserialize() {
+        let json = r#"{"limit": 10, "offset": 0}"#;
+        let query: BlockLogsQuery = serde_json::from_str(json).unwrap();
+        assert_eq!(query.limit, Some(10));
+    }
+}
+```
+
+テスト実行（Redを確認）:
+```bash
+cargo test --all-features api::
+# → コンパイルエラーまたはモジュール未発見でfail
+```
+
+#### Green（実装）
+
+1. `src/api/mod.rs` を新規作成し、`pub mod types;` と `pub mod handlers;` を定義する
+2. `src/webui/api.rs` から以下を `src/api/types.rs` にコピー（後でwebui側から削除）:
+   - 全定数（`DEFAULT_PAGE_LIMIT`等）
+   - 全型定義（`DashboardStats`等）
+3. `src/webui/api.rs` からビジネスロジック関数を `src/api/handlers.rs` にコピー:
+   - `build_dashboard_stats()`
+   - その他のヘルパー関数
+
+テスト実行（Greenを確認）:
+```bash
+cargo test --all-features api::
+# → 全テストパス
+```
+
+#### Refactor
+
+- 型定義とハンドラのモジュール境界を明確化する
+- publicインターフェースを `src/api/mod.rs` から再エクスポートする
+
+**完了基準**:
+- `src/api/` モジュールが作成され、コンパイルが通る
+- `DashboardStats` 等の型が `crate::api::DashboardStats` でアクセス可能
+- `cargo test --all-features` が全テストパス
+
+---
+
+### TASK-002: src/server/router.rs のインポートパス変更
+
+**対応要件**: REQ-103, REQ-104
+
+**依存タスク**: TASK-001
+
+**対象ファイル**:
+- `src/server/router.rs`
+
+#### Red（テスト作成）
+
+既存のルーターテストが引き続き通ることを確認するテストを追加する（既存テストをそのまま活用）。
+
+```bash
+cargo test --all-features router::
+# → TASK-001完了後の状態では、まだ旧パスを参照しているためビルドが通る状態
+```
+
+#### Green（実装）
+
+`src/server/router.rs` のインポート文を変更する:
+
+```rust
+// Before
+use crate::webui::api::{
+    self, BlockLogsQuery, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, MAX_PATTERN_LENGTH,
+    MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
+};
+
+// After
+use crate::api::{
+    self, BlockLogsQuery, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, MAX_PATTERN_LENGTH,
+    MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
+};
+```
+
+テスト実行:
+```bash
+cargo test --all-features router::
+# → 全テストパス
+```
+
+#### Refactor
+
+- インポート文の整理（未使用インポートの除去）
+
+**完了基準**:
+- `src/server/router.rs` が `crate::api` からインポートしている
+- `cargo test --all-features` が全テストパス
+
+---
+
+### TASK-003: src/lib.rs と src/webui/mod.rs の更新
+
+**対応要件**: REQ-103, REQ-105
+
+**依存タスク**: TASK-001, TASK-002
+
+**対象ファイル**:
+- `src/lib.rs`
+- `src/webui/mod.rs`
+
+#### Red（テスト作成）
+
+`src/api` モジュールが `crate` ルートから直接アクセスできることを確認するテスト。
+
+```rust
+// src/lib.rs 経由でアクセスできることをコンパイルテストで確認
+// tests/common/mod.rs などに追加
+// use registry_firewall::api::DashboardStats;  // これがコンパイルできればOK
+```
+
+#### Green（実装）
+
+1. `src/lib.rs` に `pub mod api;` を追加する:
+
+```rust
+// Before
+pub mod webui;
+
+// After  (一時的に両方を残す)
+pub mod api;
+pub mod webui;
+```
+
+2. `src/webui/mod.rs` から `pub mod api;` と `pub use api::*;` を削除する:
+
+```rust
+// Before
+pub mod api;
+pub use api::*;
+use rust_embed::RustEmbed;
+...
+
+// After
+// api モジュールは src/api/ に移動したため削除
+use rust_embed::RustEmbed;
+...
+```
+
+テスト実行:
+```bash
+cargo test --all-features
+# → 全テストパス
+```
+
+#### Refactor
+
+- `src/webui/api.rs` ファイル自体を削除する（内容は `src/api/` に移動済み）
+- 不要なre-exportがないことを確認する
+
+**完了基準**:
+- `crate::api::DashboardStats` でアクセス可能
+- `src/webui/api.rs` が削除されている
+- `cargo test --all-features` が全テストパス
+
+---
+
+## Phase 2: Cargo features導入
+
+**目的**: `webui` と `swagger-gen` featureを定義し、featureフラグによる条件付きコンパイルを実装する。
+
+**前提**: Phase 1完了
+
+**完了基準**: `cargo test --all-features` と `cargo test --no-default-features` の両方が全テストパス
+
+---
+
+### TASK-004: Cargo.toml features定義と依存クレートのoptional化
+
+**対応要件**: REQ-101, REQ-102, REQ-105, REQ-120
+
+**依存タスク**: TASK-003（Phase 1完了）
+
+**対象ファイル**:
+- `Cargo.toml`
+
+#### Red（テスト作成）
+
+`cargo build --no-default-features` がコンパイルエラーになることを確認する（現時点では `rust-embed` が通常依存のため、このコマンドは成功するが、feature設定前後の動作差分を把握するために実行する）。
+
+```bash
+# 現状の確認
+cargo build --no-default-features
+# → 現在は全依存が通常依存のため成功
+
+# feature変更後にrust-embedがオプションになった後:
+cargo build --no-default-features
+# → rust-embedを参照するコードがcfg(feature)で囲まれていなければエラー
+```
+
+#### Green（実装）
+
+`Cargo.toml` に以下を追加・変更する:
+
+```toml
+[features]
+default = ["webui"]
+webui = ["dep:rust-embed", "dep:mime_guess"]
+swagger-gen = ["dep:utoipa", "dep:utoipa-axum", "dep:utoipa-swagger-ui"]
+
+[dependencies]
+# ... 既存の依存 ...
+
+# Embed static files (optional, enabled by "webui" feature)
+rust-embed = { version = "8", optional = true }
+mime_guess = { version = "2", optional = true }
+
+# OpenAPI specification generation (optional, enabled by "swagger-gen" feature)
+utoipa = { version = "4", features = ["axum_extras", "chrono"], optional = true }
+utoipa-axum = { version = "0.1", optional = true }
+utoipa-swagger-ui = { version = "7", features = ["axum"], optional = true }
+```
+
+テスト実行:
+```bash
+cargo build --all-features
+# → ビルド成功（依存関係の解決確認）
+```
+
+#### Refactor
+
+- 依存クレートのバージョン指定が設計書と一致していることを確認する
+
+**完了基準**:
+- `[features]` セクションが定義されている（`default`, `webui`, `swagger-gen`）
+- `rust-embed` と `mime_guess` が `optional = true` になっている
+- `utoipa`、`utoipa-axum`、`utoipa-swagger-ui` が optional 依存として追加されている
+- `cargo build --all-features` が成功する
+
+---
+
+### TASK-005: src/lib.rs に cfg(feature = "webui") 適用
+
+**対応要件**: REQ-102, REQ-105
+
+**依存タスク**: TASK-004
+
+**対象ファイル**:
+- `src/lib.rs`
+
+#### Red（テスト作成）
+
+```bash
+# webui featureなしでビルドした際にsrc/webui/mod.rsがコンパイル対象外になることを確認
+cargo build --no-default-features
+# → 現状ではsrc/webui/が含まれるためrust-embedへの参照でエラー
+```
+
+#### Green（実装）
+
+`src/lib.rs` の `webui` モジュール宣言に `#[cfg(feature = "webui")]` を追加する:
+
+```rust
+// Before
+pub mod api;
+pub mod webui;
+
+// After
+pub mod api;  // feature非依存: REST API型定義とロジック
+
+#[cfg(feature = "webui")]
+pub mod webui;  // webui feature時のみ: 静的ファイル配信
+```
+
+テスト実行:
+```bash
+cargo build --no-default-features
+# → src/webui/がコンパイル対象外になる（rust-embedへの参照がない）
+cargo build --all-features
+# → 全機能でビルド成功
+```
+
+#### Refactor
+
+- モジュール宣言のコメントが設計書と一致していることを確認する
+
+**完了基準**:
+- `pub mod webui;` に `#[cfg(feature = "webui")]` が付いている
+- `cargo build --no-default-features` が成功する
+- `cargo build --all-features` が成功する
+
+---
+
+### TASK-006: src/server/router.rs の条件付きルート・ハンドラ実装
+
+**対応要件**: REQ-103, REQ-104
+
+**依存タスク**: TASK-005
+
+**対象ファイル**:
+- `src/server/router.rs`
+
+#### Red（テスト作成）
+
+`webui` featureなしビルドで `/ui` エンドポイントが存在しないことを確認するテストを追加する:
+
+```rust
+// Test: webui featureなしでは/uiが404を返すことを確認
+// Note: このテストはcfg(not(feature = "webui"))で条件付きにする
+#[cfg(not(feature = "webui"))]
+#[tokio::test]
+async fn test_webui_not_available_without_feature() {
+    // ... テスト実装 ...
+    // GET /ui → 404
+}
+```
+
+```bash
+cargo test --no-default-features router::
+# → webui関連ハンドラへの参照でコンパイルエラー（Redを確認）
+```
+
+#### Green（実装）
+
+1. `build_router()` 内のWeb UIルートを条件付きに変更する:
+
+```rust
+pub fn build_router<D: Database + 'static>(state: AppState<D>) -> Router {
+    let auth_manager = Arc::clone(&state.auth_manager);
+
+    let router = Router::new()
+        // ... 既存のルート（変更なし）
+        ;
+
+    #[cfg(feature = "webui")]
+    let router = router
+        .route("/ui", get(webui_index_handler))
+        .route("/ui/*path", get(webui_static_handler));
+
+    router
+        .layer(middleware::from_fn_with_state(
+            auth_manager,
+            auth_middleware,
+        ))
+        .with_state(state)
+}
+```
+
+2. Web UIハンドラに `#[cfg(feature = "webui")]` を付ける:
+
+```rust
+#[cfg(feature = "webui")]
+async fn webui_index_handler() -> impl IntoResponse {
+    crate::webui::serve_index()
+}
+
+#[cfg(feature = "webui")]
+async fn webui_static_handler(Path(path): Path<String>) -> impl IntoResponse {
+    crate::webui::serve_static(&path)
+}
+```
+
+3. 既存の `test_webui_index_endpoint` と `test_webui_static_endpoint` に `#[cfg(feature = "webui")]` を付ける:
+
+```rust
+#[cfg(feature = "webui")]
+#[tokio::test]
+async fn test_webui_index_endpoint() { ... }
+
+#[cfg(feature = "webui")]
+#[tokio::test]
+async fn test_webui_static_endpoint() { ... }
+```
+
+テスト実行:
+```bash
+cargo test --all-features router::
+# → 全テストパス（webui関連テストを含む）
+
+cargo test --no-default-features router::
+# → webui関連テストは実行されず、APIテストは全パス
+```
+
+#### Refactor
+
+- `#[cfg(feature = "webui")]` の付与漏れがないことを確認する
+
+**完了基準**:
+- `cargo test --all-features` が全テストパス
+- `cargo test --no-default-features` が全テストパス
+- `cargo test --no-default-features` でwebui関連テストがスキップされる
+
+---
+
+## Phase 3: Dockerfile変更
+
+**目的**: APIのみイメージとGUI付きイメージの2種類のDockerfileを用意する。
+
+**前提**: Phase 2完了
+
+**完了基準**: 両Dockerfileのビルド成功（ローカル環境での `docker build` 成功）
+
+---
+
+### TASK-007: deployments/docker/Dockerfile をAPIのみ用に変更
+
+**対応要件**: REQ-106, REQ-107, NFR-101, NFR-103, NFR-108
+
+**依存タスク**: TASK-006（Phase 2完了）
+
+**対象ファイル**:
+- `deployments/docker/Dockerfile`
+
+#### Red（テスト作成）
+
+現状のDockerfileをビルドして、`web/dist/` が含まれていることを確認する:
+
+```bash
+docker build -f deployments/docker/Dockerfile -t registry-firewall:before-test .
+# → 現状はweb/distをコピーしてwebui付きでビルド
+```
+
+#### Green（実装）
+
+`deployments/docker/Dockerfile` を以下のように変更する:
+
+1. `ARG CARGO_BUILD_FEATURES` と関連するshell条件分岐を削除する（APIのみDockerfileは常に `--no-default-features`）
+2. `COPY web web/` を削除する（web/distが不要）
+3. ビルドコマンドを `cargo build --release --no-default-features` に固定する
+
+設計書 3.2節の Dockerfile を参照しつつ、APIのみ用に簡略化する:
+- builder ステージでは `--no-default-features` を使用
+- `COPY web web/` ステップを除去
+- 設計書 3.4節の「APIのみビルドのDockerfile」の仕様に従う
+
+テスト実行:
+```bash
+docker build -f deployments/docker/Dockerfile -t registry-firewall:api-only .
+# → ビルド成功
+
+docker run --rm registry-firewall:api-only registry-firewall --help
+# → ヘルプが表示される（バイナリが動作する）
+```
+
+#### Refactor
+
+- Dockerfileのコメントを更新し、APIのみ用であることを明記する
+
+**完了基準**:
+- `docker build -f deployments/docker/Dockerfile` が成功する
+- `COPY web web/` が含まれていない
+- `--no-default-features` でビルドされている
+
+---
+
+### TASK-008: deployments/docker/Dockerfile.full を新規作成
+
+**対応要件**: REQ-110, REQ-114, REQ-115, REQ-116, NFR-102
+
+**依存タスク**: TASK-007
+
+**対象ファイル**:
+- `deployments/docker/Dockerfile.full` （新規作成）
+
+#### Red（テスト作成）
+
+`Dockerfile.full` が存在しないことを確認する:
+
+```bash
+ls deployments/docker/Dockerfile.full
+# → No such file（Redを確認）
+```
+
+#### Green（実装）
+
+`deployments/docker/Dockerfile.full` を新規作成する。設計書 3.2節の設計に従い、以下の3ステージ構成にする:
+
+- **Stage 1 (builder)**: `cargo build --release --features webui`
+- **Stage 2 (node-build)**: `npm run build` でフロントエンドをビルド
+- **Stage 3 (runtime)**: `debian:bookworm-slim` ベース、バイナリとconfigのみコピー
+
+設計書 3.2節のDockerfileを参照して実装する。
+
+テスト実行:
+```bash
+docker build -f deployments/docker/Dockerfile.full -t registry-firewall:full .
+# → ビルド成功
+
+docker run --rm -p 8080:8080 registry-firewall:full registry-firewall --help
+# → ヘルプが表示される
+```
+
+#### Refactor
+
+- TASK-007のDockerfileと共通部分（runtimeステージ等）の整合性を確認する
+
+**完了基準**:
+- `deployments/docker/Dockerfile.full` が存在する
+- `docker build -f deployments/docker/Dockerfile.full` が成功する
+- node-buildステージを含む3ステージ構成になっている
+- `--features webui` でビルドされている
+
+---
+
+## Phase 4: utoipa統合
+
+**目的**: OpenAPI仕様の自動生成機能を実装する。
+
+**前提**: Phase 2完了（Phase 3と並列実行可能）
+
+**完了基準**: `cargo run --features swagger-gen -- --generate-swagger` で `swagger.json` が生成される
+
+---
+
+### TASK-009: Cargo.toml への utoipa 依存追加確認
+
+**対応要件**: REQ-120
+
+**依存タスク**: TASK-004（TASK-004で既にutoipa依存を追加済み）
+
+**対象ファイル**:
+- `Cargo.toml`
+
+**注意**: このタスクは TASK-004 で utoipa 依存を追加した場合は確認のみ。TASK-004 で対応済みであれば TASK-009 はスキップ可能。
+
+#### Green（確認）
+
+`Cargo.toml` に以下が含まれていることを確認する:
+
+```toml
+utoipa = { version = "4", features = ["axum_extras", "chrono"], optional = true }
+utoipa-axum = { version = "0.1", optional = true }
+utoipa-swagger-ui = { version = "7", features = ["axum"], optional = true }
+```
+
+```bash
+cargo build --features swagger-gen
+# → utoipaクレートがダウンロード・コンパイルされる
+```
+
+**完了基準**:
+- `cargo build --features swagger-gen` が成功する
+- `cargo build --no-default-features` が引き続き成功する
+
+---
+
+### TASK-010: API型定義に ToSchema derive 追加
+
+**対応要件**: REQ-122
+
+**依存タスク**: TASK-009
+
+**対象ファイル**:
+- `src/api/types.rs`
+- `src/models/` 内の対象ファイル（`CustomRule`を含むファイル）
+
+#### Red（テスト作成）
+
+`ToSchema` が derive されていない状態で `swagger-gen` featureを有効にしてコンパイルしようとすると、後のステップでエラーになることを確認する（`ApiDoc` 未定義のため、このステップ単体ではビルドが通る）。
+
+#### Green（実装）
+
+設計書 5.2節に記載されたすべての構造体に `ToSchema` を追加する。
+
+`src/api/types.rs` の各構造体（`swagger-gen` feature有効時のみ）:
+
+```rust
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DashboardStats {
+    ...
+}
+```
+
+対象構造体（設計書 5.2節より）:
+- `DashboardStats`
+- `SecuritySourceSummary`
+- `BlockLogsQuery`
+- `BlockLogsResponse`
+- `BlockLogEntry`
+- `SecuritySourcesResponse`
+- `SecuritySourceInfo`
+- `SyncTriggerResponse`
+- `CacheStatsResponse`
+- `CacheClearResponse`
+- `RulesResponse`
+- `TokensResponse`
+- `TokenInfo`
+- `CreateTokenRequest`
+- `CreateTokenResponse`
+- `MessageResponse`
+- `ErrorResponse`
+
+`src/server/router.rs` の `CreateTokenApiRequest` にも同様に追加する。
+
+`src/models/` の `CustomRule` にも追加する。
+
+テスト実行:
+```bash
+cargo build --features swagger-gen
+# → ToSchema derivationが正常にコンパイルされる
+cargo build --no-default-features
+# → 引き続き成功
+```
+
+#### Refactor
+
+- `cfg_attr` の書き方が一貫していることを確認する
+
+**完了基準**:
+- 設計書 5.2節の全構造体に `ToSchema` が追加されている
+- `cargo build --features swagger-gen` が成功する
+- `cargo build --no-default-features` が成功する
+
+---
+
+### TASK-011: ハンドラへの #[utoipa::path] アノテーション追加
+
+**対応要件**: REQ-121
+
+**依存タスク**: TASK-010
+
+**対象ファイル**:
+- `src/server/router.rs`
+
+#### Red（テスト作成）
+
+アノテーションなしの状態では `ApiDoc` に全エンドポイントが含まれないことを確認する（TASK-012実装後にテスト可能）。このタスクでは設計書のアノテーション例を参考にコンパイル確認を行う。
+
+#### Green（実装）
+
+設計書 5.1節の全エンドポイントに `#[cfg_attr(feature = "swagger-gen", utoipa::path(...))]` を追加する:
+
+```rust
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    get,
+    path = "/api/dashboard",
+    responses(
+        (status = 200, description = "Dashboard statistics", body = DashboardStats),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+    ),
+    security(
+        ("bearer_token" = []),
+        ("basic_auth" = []),
+    ),
+    tag = "dashboard"
+))]
+async fn api_dashboard_handler<D: Database + 'static>(
+    State(state): State<AppState<D>>,
+) -> impl IntoResponse {
+    ...
+}
+```
+
+対象エンドポイント（設計書 5.1節より）:
+- `api_dashboard_handler` (GET /api/dashboard)
+- `api_blocks_handler` (GET /api/blocks)
+- `api_security_sources_handler` (GET /api/security-sources)
+- `api_trigger_sync_handler` (POST /api/security-sources/{name}/sync)
+- `api_cache_stats_handler` (GET /api/cache/stats)
+- `api_cache_clear_handler` (DELETE /api/cache)
+- `api_list_rules_handler` (GET /api/rules)
+- `api_create_rule_handler` (POST /api/rules)
+- `api_get_rule_handler` (GET /api/rules/{id})
+- `api_update_rule_handler` (PUT /api/rules/{id})
+- `api_delete_rule_handler` (DELETE /api/rules/{id})
+- `api_list_tokens_handler` (GET /api/tokens)
+- `api_create_token_handler` (POST /api/tokens)
+- `api_delete_token_handler` (DELETE /api/tokens/{id})
+
+テスト実行:
+```bash
+cargo build --features swagger-gen
+# → アノテーションが正常にコンパイルされる
+cargo build --no-default-features
+# → アノテーションがコンパイル対象外（cfg_attr）
+```
+
+#### Refactor
+
+- アノテーションの記述スタイルが一貫していることを確認する
+- `security` フィールドが全エンドポイントに設定されていることを確認する
+
+**完了基準**:
+- 設計書 5.1節の全14エンドポイントにアノテーションが付いている
+- `cargo build --features swagger-gen` が成功する
+- `cargo build --no-default-features` が成功する
+
+---
+
+### TASK-012: ApiDoc 構造体と SecurityAddon 実装
+
+**対応要件**: REQ-125, REQ-126, REQ-129
+
+**依存タスク**: TASK-011
+
+**対象ファイル**:
+- `src/api/openapi.rs` （新規作成）
+- `src/api/mod.rs` （`openapi` モジュールの追加）
+- `src/server/router.rs` （Swagger UI エンドポイントの追加）
+
+#### Red（テスト作成）
+
+`ApiDoc::openapi()` が有効なOpenAPI仕様を生成することを確認するテストを追加する:
+
+```rust
+// src/api/openapi.rs のテスト
+#[cfg(test)]
+#[cfg(feature = "swagger-gen")]
+mod tests {
+    use super::*;
+    use utoipa::OpenApi;
+
+    // TASK-012-T1: ApiDocがOpenAPI仕様を生成できること
+    #[test]
+    fn test_apidoc_generates_openapi() {
+        let openapi = ApiDoc::openapi();
+        let json = openapi.to_pretty_json().unwrap();
+        assert!(!json.is_empty());
+    }
+
+    // TASK-012-T2: バージョンがCargo.tomlと一致すること
+    #[test]
+    fn test_apidoc_version_matches_cargo() {
+        let openapi = ApiDoc::openapi();
+        assert_eq!(openapi.info.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    // TASK-012-T3: securitySchemesにbearer_tokenとbasic_authが含まれること
+    #[test]
+    fn test_apidoc_security_schemes() {
+        let openapi = ApiDoc::openapi();
+        let components = openapi.components.unwrap();
+        assert!(components.security_schemes.contains_key("bearer_token"));
+        assert!(components.security_schemes.contains_key("basic_auth"));
+    }
+}
+```
+
+```bash
+cargo test --features swagger-gen api::openapi::
+# → モジュール未定義でfail（Redを確認）
+```
+
+#### Green（実装）
+
+1. `src/api/openapi.rs` を新規作成し、設計書 5.4節の `ApiDoc`、`SecurityAddon`、`ServerAddon` を実装する
+2. `src/api/mod.rs` に `#[cfg(feature = "swagger-gen")] pub mod openapi;` を追加する
+3. `src/server/router.rs` に Swagger UI エンドポイントを追加する（設計書 5.6節）:
+
+```rust
+#[cfg(all(feature = "webui", feature = "swagger-gen"))]
+let router = router.merge(
+    utoipa_swagger_ui::SwaggerUi::new("/api/swagger-ui")
+        .url("/api/openapi.json", ApiDoc::openapi())
+);
+```
+
+テスト実行:
+```bash
+cargo test --features swagger-gen api::openapi::
+# → 全テストパス
+cargo test --all-features
+# → 全テストパス
+```
+
+#### Refactor
+
+- `ServerAddon` のサーバー定義にプレースホルダーを使用する（REQ-129 / NFR-109）
+- タグ定義が設計書 5.4節と一致していることを確認する
+
+**完了基準**:
+- `ApiDoc::openapi()` が呼び出し可能
+- バージョンが `CARGO_PKG_VERSION` と一致する
+- `bearer_token` と `basic_auth` のsecuritySchemesが含まれる
+- `cargo test --features swagger-gen` が全テストパス
+
+---
+
+### TASK-013: --generate-swagger CLIオプション実装
+
+**対応要件**: REQ-123
+
+**依存タスク**: TASK-012
+
+**対象ファイル**:
+- `src/main.rs`
+
+#### Red（テスト作成）
+
+`--generate-swagger` オプションを指定しても `swagger.json` が生成されないことを確認する:
+
+```bash
+cargo run --features swagger-gen -- --generate-swagger
+# → 引数が認識されず、サーバー起動を試みる（Redを確認）
+```
+
+#### Green（実装）
+
+設計書 5.5節に従い `src/main.rs` に以下を追加する:
+
+1. `Args` 構造体に `--generate-swagger` フラグを追加する:
+
+```rust
+/// Generate OpenAPI specification (swagger.json) and exit
+#[cfg(feature = "swagger-gen")]
+#[arg(long)]
+generate_swagger: bool,
+```
+
+2. `main()` に処理を追加する:
+
+```rust
+#[cfg(feature = "swagger-gen")]
+if args.generate_swagger {
+    use registry_firewall::api::openapi::ApiDoc;
+    use utoipa::OpenApi;
+    let spec = ApiDoc::openapi()
+        .to_pretty_json()
+        .expect("Failed to serialize OpenAPI spec");
+    std::fs::write("swagger.json", spec)
+        .expect("Failed to write swagger.json");
+    eprintln!("swagger.json generated successfully");
+    return Ok(());
+}
+```
+
+テスト実行:
+```bash
+cargo run --features swagger-gen -- --generate-swagger
+# → swagger.json が生成される
+
+ls -la swagger.json
+# → ファイルが存在する
+
+# OpenAPI 3.0フォーマットの確認
+cat swagger.json | python3 -m json.tool > /dev/null
+# → JSONとして有効
+```
+
+#### Refactor
+
+- `swagger.json` の出力パスが設計書と一致していることを確認する（カレントディレクトリ）
+
+**完了基準**:
+- `cargo run --features swagger-gen -- --generate-swagger` で `swagger.json` が生成される
+- 生成されたJSONが有効なOpenAPI 3.0フォーマット
+- バージョンが `Cargo.toml` のバージョンと一致する
+- `cargo run --no-default-features -- --help` が成功する（`--generate-swagger` オプションが表示されない）
+
+---
+
+## Phase 5: CI/CD変更
+
+**目的**: GitHub Actions ワークフローをデュアルイメージとswagger.json生成に対応させる。
+
+**前提**: Phase 3完了、Phase 4完了
+
+**完了基準**: ワークフローファイルが設計書と一致する
+
+---
+
+### TASK-014: ci.yml に test-no-default-features ジョブ追加
+
+**対応要件**: REQ-104（CIでの検証）
+
+**依存タスク**: TASK-006（Phase 2完了）
+
+**対象ファイル**:
+- `.github/workflows/ci.yml`
+
+#### Red（テスト作成）
+
+`test-no-default-features` ジョブが存在しないことを確認する:
+
+```bash
+grep -n "test-no-default-features" .github/workflows/ci.yml
+# → 見つからない（Redを確認）
+```
+
+#### Green（実装）
+
+設計書 6.1節に従い、`test-no-default-features` ジョブを `ci.yml` に追加する:
+
+```yaml
+test-no-default-features:
+  name: Test (no default features)
+  runs-on: ubuntu-latest
+  needs: changes
+  if: ${{ needs.changes.outputs.rust == 'true' }}
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Build without default features
+      run: cargo build --no-default-features
+
+    - name: Run tests without default features
+      run: cargo test --no-default-features
+```
+
+テスト実行（YAMLの妥当性確認）:
+```bash
+# GitHub Actions のYAML構文確認
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+# → エラーなし
+```
+
+#### Refactor
+
+- ジョブの配置位置が既存の `test` ジョブの近くになっていることを確認する
+
+**完了基準**:
+- `ci.yml` に `test-no-default-features` ジョブが追加されている
+- ジョブは `cargo build --no-default-features` と `cargo test --no-default-features` を実行する
+- YAMLとして構文的に正しい
+
+---
+
+### TASK-015: ci.yml の docker-build ジョブを Dockerfile.full 対応に拡張
+
+**対応要件**: REQ-110（CI段階での検証）
+
+**依存タスク**: TASK-008, TASK-014
+
+**対象ファイル**:
+- `.github/workflows/ci.yml`
+
+#### Red（テスト作成）
+
+既存の `docker-build` ジョブが `Dockerfile.full` をビルドしないことを確認する:
+
+```bash
+grep -n "Dockerfile.full" .github/workflows/ci.yml
+# → 見つからない（Redを確認）
+```
+
+#### Green（実装）
+
+設計書 6.3節に従い、`docker-build` ジョブに `Dockerfile.full` のビルドステップを追加する:
+
+```yaml
+- name: Build full Docker image (no push)
+  uses: docker/build-push-action@v7
+  with:
+    context: .
+    file: deployments/docker/Dockerfile.full
+    push: false
+    tags: registry-firewall:ci-check-full
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+既存のDockerfileのビルドステップのタグも `registry-firewall:ci-check-api` に変更する（設計書 6.3節に合わせる）。
+
+テスト実行（YAMLの妥当性確認）:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
+# → エラーなし
+```
+
+**完了基準**:
+- `docker-build` ジョブが `Dockerfile` と `Dockerfile.full` の両方をビルドする
+- YAMLとして構文的に正しい
+
+---
+
+### TASK-016: release.yml のデュアルイメージビルド実装
+
+**対応要件**: REQ-110, REQ-111, REQ-112, REQ-113, REQ-115, NFR-104, NFR-105
+
+**依存タスク**: TASK-015
+
+**対象ファイル**:
+- `.github/workflows/release.yml`
+
+#### Red（テスト作成）
+
+現状の `release.yml` が単一イメージのみをビルドすることを確認する:
+
+```bash
+grep -n "build-docker-full\|Dockerfile.full" .github/workflows/release.yml
+# → 見つからない（Redを確認）
+```
+
+#### Green（実装）
+
+設計書 4.1〜4.3節に従い、`release.yml` を変更する:
+
+1. 既存の `build-and-push-docker` ジョブを `build-docker-api` にリネームし、APIのみイメージのタグ設定に変更する
+2. `build-docker-full` ジョブを新規追加する（設計書 4.3節の YAML を参照）
+3. `create-release` ジョブの `needs` を `[test, generate-swagger, build-docker-api, build-docker-full]` に更新する
+
+タグ命名規則（設計書 4.2節）:
+- APIのみ: `latest`, `X.Y.Z`, `X.Y`, `X`（安定版のみlatest付与）
+- GUI付き: `latest-full`, `X.Y.Z-full`, `X.Y-full`, `X-full`（安定版のみlatest-full付与）
+
+テスト実行（YAMLの妥当性確認）:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"
+# → エラーなし
+```
+
+#### Refactor
+
+- `build-docker-api` と `build-docker-full` が並列実行されることを確認する（両ジョブの `needs` が `test` のみであること）
+
+**完了基準**:
+- `build-docker-api` ジョブが `Dockerfile` を使用してAPIのみイメージをビルド・プッシュする
+- `build-docker-full` ジョブが `Dockerfile.full` を使用してGUI付きイメージをビルド・プッシュする
+- プレリリース時は `latest` / `latest-full` タグが付与されない
+- 両ジョブが `test` ジョブ完了後に並列実行される
+- YAMLとして構文的に正しい
+
+---
+
+### TASK-017: release.yml の swagger.json 生成・リリースアセット添付
+
+**対応要件**: REQ-124
+
+**依存タスク**: TASK-013, TASK-016
+
+**対象ファイル**:
+- `.github/workflows/release.yml`
+
+#### Red（テスト作成）
+
+現状の `release.yml` が `generate-swagger` ジョブを持たず、`swagger.json` をリリースアセットに添付しないことを確認する:
+
+```bash
+grep -n "generate-swagger\|swagger.json" .github/workflows/release.yml
+# → 見つからない（Redを確認）
+```
+
+#### Green（実装）
+
+設計書 4.1〜4.3節に従い、以下を追加する:
+
+1. `generate-swagger` ジョブを追加する（設計書 4.3節の YAML を参照）:
+   - `needs: test` で `test` ジョブ完了後に実行
+   - `cargo run --features swagger-gen -- --generate-swagger` を実行
+   - `actions/upload-artifact` で `swagger-json` アーティファクトとしてアップロード
+
+2. `create-release` ジョブを変更する:
+   - `needs` に `generate-swagger` を追加する
+   - `actions/download-artifact` で `swagger-json` をダウンロードする
+   - `softprops/action-gh-release` の `files` に `swagger.json` を追加する
+
+テスト実行（YAMLの妥当性確認）:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"
+# → エラーなし
+```
+
+#### Refactor
+
+- `generate-swagger` と `build-docker-api`、`build-docker-full` が並列実行されることを確認する（いずれも `needs: test` のみ）
+
+**完了基準**:
+- `generate-swagger` ジョブが追加されている
+- `create-release` ジョブが `swagger.json` をリリースアセットに添付する
+- `generate-swagger`、`build-docker-api`、`build-docker-full` が並列実行可能
+- YAMLとして構文的に正しい
+
+---
+
+## タスクステータス一覧
+
+| タスクID | タイトル | フェーズ | 依存タスク | ステータス |
+|---------|--------|---------|-----------|---------|
+| TASK-001 | src/api/ モジュール新規作成 | Phase 1 | なし | TODO |
+| TASK-002 | router.rs インポートパス変更 | Phase 1 | TASK-001 | TODO |
+| TASK-003 | lib.rs・webui/mod.rs 更新 | Phase 1 | TASK-001, TASK-002 | TODO |
+| TASK-004 | Cargo.toml features定義 | Phase 2 | TASK-003 | TODO |
+| TASK-005 | lib.rs cfg(feature = "webui")適用 | Phase 2 | TASK-004 | TODO |
+| TASK-006 | router.rs 条件付きルート・ハンドラ | Phase 2 | TASK-005 | TODO |
+| TASK-007 | Dockerfile APIのみ用に変更 | Phase 3 | TASK-006 | TODO |
+| TASK-008 | Dockerfile.full 新規作成 | Phase 3 | TASK-007 | TODO |
+| TASK-009 | utoipa依存追加確認 | Phase 4 | TASK-004 | TODO |
+| TASK-010 | ToSchema derive追加 | Phase 4 | TASK-009 | TODO |
+| TASK-011 | #[utoipa::path]アノテーション追加 | Phase 4 | TASK-010 | TODO |
+| TASK-012 | ApiDoc・SecurityAddon実装 | Phase 4 | TASK-011 | TODO |
+| TASK-013 | --generate-swagger CLIオプション | Phase 4 | TASK-012 | TODO |
+| TASK-014 | ci.yml no-default-featuresジョブ追加 | Phase 5 | TASK-006 | TODO |
+| TASK-015 | ci.yml docker-buildジョブ拡張 | Phase 5 | TASK-008, TASK-014 | TODO |
+| TASK-016 | release.yml デュアルイメージビルド | Phase 5 | TASK-015 | TODO |
+| TASK-017 | release.yml swagger.json生成・添付 | Phase 5 | TASK-013, TASK-016 | TODO |
+
+---
+
+## 変更ファイル一覧（設計書との対応）
+
+| ファイル | 変更種別 | 対応タスク | 対応要件 |
+|---------|---------|-----------|---------|
+| `Cargo.toml` | 変更 | TASK-004 | REQ-101, REQ-102, REQ-105, REQ-120 |
+| `src/lib.rs` | 変更 | TASK-003, TASK-005 | REQ-103, REQ-105 |
+| `src/api/mod.rs` | 新規 | TASK-001 | REQ-103, REQ-104 |
+| `src/api/types.rs` | 新規 | TASK-001, TASK-010 | REQ-103, REQ-122 |
+| `src/api/handlers.rs` | 新規 | TASK-001 | REQ-103 |
+| `src/api/openapi.rs` | 新規 | TASK-012 | REQ-125, REQ-126, REQ-129 |
+| `src/webui/mod.rs` | 変更 | TASK-003 | REQ-105 |
+| `src/webui/api.rs` | 削除 | TASK-003 | REQ-105 |
+| `src/server/router.rs` | 変更 | TASK-002, TASK-006, TASK-011 | REQ-103, REQ-104, REQ-121 |
+| `src/main.rs` | 変更 | TASK-013 | REQ-123 |
+| `deployments/docker/Dockerfile` | 変更 | TASK-007 | REQ-106, REQ-107, NFR-101 |
+| `deployments/docker/Dockerfile.full` | 新規 | TASK-008 | REQ-114, REQ-115, REQ-116, NFR-102 |
+| `.github/workflows/ci.yml` | 変更 | TASK-014, TASK-015 | REQ-104 |
+| `.github/workflows/release.yml` | 変更 | TASK-016, TASK-017 | REQ-110〜REQ-113, REQ-124, NFR-104, NFR-105 |
+
+---
+
+## 変更履歴
+
+| バージョン | 日付 | 変更内容 |
+|-----------|------|---------|
+| 1.0 | 2026-03-18 | 初版作成 |

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -1,0 +1,344 @@
+//! API handler functions
+//!
+//! This module contains business logic functions for the REST API endpoints.
+
+use std::sync::Arc;
+
+use crate::database::Database;
+use crate::plugins::cache::traits::CachePlugin;
+use crate::plugins::security::traits::SecuritySourcePlugin;
+use crate::sync::ManualSyncHandle;
+
+use super::types::{
+    BlockLogEntry, BlockLogsResponse, CacheStatsResponse, DashboardStats, SecuritySourceInfo,
+    SecuritySourceSummary, SecuritySourcesResponse, SyncTriggerResponse,
+};
+
+// =============================================================================
+// API Functions
+// =============================================================================
+
+/// Build dashboard statistics from application state
+pub async fn build_dashboard_stats<D: Database>(
+    database: &D,
+    security_plugins: &[Arc<dyn SecuritySourcePlugin>],
+    cache_plugin: &Option<Arc<dyn CachePlugin>>,
+) -> DashboardStats {
+    // Get block logs count for blocked_requests
+    let blocked_requests = database.get_block_logs_count().await.unwrap_or(0);
+
+    // Get cache stats if available
+    let (cache_hit_rate, total_requests) = if let Some(cache) = cache_plugin {
+        let stats = cache.stats().await;
+        let total = stats.hits + stats.misses;
+        let hit_rate = if total > 0 {
+            stats.hits as f64 / total as f64
+        } else {
+            0.0
+        };
+        (hit_rate, total)
+    } else {
+        (0.0, 0)
+    };
+
+    // Build security source summaries
+    let security_sources: Vec<SecuritySourceSummary> = security_plugins
+        .iter()
+        .map(|p| {
+            let status = p.sync_status();
+            SecuritySourceSummary {
+                name: p.name().to_string(),
+                ecosystems: p.supported_ecosystems().to_vec(),
+                last_sync: status.last_sync_at,
+                status: status.status.to_string(),
+                records_count: status.records_count,
+            }
+        })
+        .collect();
+
+    // Calculate total blocked packages
+    let blocked_packages_count: u64 = security_sources.iter().map(|s| s.records_count).sum();
+
+    DashboardStats {
+        total_requests,
+        blocked_requests,
+        cache_hit_rate,
+        security_sources_count: security_plugins.len(),
+        blocked_packages_count,
+        security_sources,
+    }
+}
+
+/// Get block logs from database
+pub async fn get_block_logs<D: Database>(
+    database: &D,
+    limit: u32,
+    offset: u32,
+) -> Result<BlockLogsResponse, String> {
+    let logs = database
+        .get_block_logs(limit, offset)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let total = database
+        .get_block_logs_count()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(BlockLogsResponse {
+        logs: logs.into_iter().map(BlockLogEntry::from).collect(),
+        total,
+    })
+}
+
+/// Build security sources response
+pub fn build_security_sources_response(
+    security_plugins: &[Arc<dyn SecuritySourcePlugin>],
+) -> SecuritySourcesResponse {
+    let sources: Vec<SecuritySourceInfo> = security_plugins
+        .iter()
+        .map(|p| {
+            let status = p.sync_status();
+            SecuritySourceInfo {
+                name: p.name().to_string(),
+                ecosystems: p.supported_ecosystems().to_vec(),
+                last_sync: status.last_sync_at,
+                status: status.status.to_string(),
+                records_count: status.records_count,
+            }
+        })
+        .collect();
+
+    SecuritySourcesResponse { sources }
+}
+
+/// Trigger sync for a security source
+pub async fn trigger_sync(
+    sync_handle: &ManualSyncHandle,
+    source_name: &str,
+) -> SyncTriggerResponse {
+    match sync_handle.trigger_sync(source_name).await {
+        Ok(result) => SyncTriggerResponse {
+            message: format!("Sync completed for {}", source_name),
+            success: true,
+            records_updated: Some(result.records_updated),
+        },
+        Err(e) => SyncTriggerResponse {
+            message: format!("Sync failed for {}: {}", source_name, e),
+            success: false,
+            records_updated: None,
+        },
+    }
+}
+
+/// Get cache statistics
+pub async fn get_cache_stats(cache_plugin: &Option<Arc<dyn CachePlugin>>) -> CacheStatsResponse {
+    if let Some(cache) = cache_plugin {
+        let stats = cache.stats().await;
+        CacheStatsResponse {
+            plugin: cache.name().to_string(),
+            hits: stats.hits,
+            misses: stats.misses,
+            total_size_bytes: stats.total_size_bytes,
+            entries: stats.entries,
+        }
+    } else {
+        CacheStatsResponse {
+            plugin: "none".to_string(),
+            hits: 0,
+            misses: 0,
+            total_size_bytes: 0,
+            entries: 0,
+        }
+    }
+}
+
+/// Clear cache
+pub async fn clear_cache(cache_plugin: &Option<Arc<dyn CachePlugin>>) -> Result<(), String> {
+    if let Some(cache) = cache_plugin {
+        cache.purge().await.map_err(|e| e.to_string())
+    } else {
+        Ok(())
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::MockDatabase;
+    use crate::models::SyncStatus;
+    use crate::models::{BlockLog, SyncStatusValue};
+    use crate::plugins::cache::traits::MockCachePlugin;
+    use crate::plugins::cache::CacheStats;
+    use crate::plugins::security::traits::MockSecuritySourcePlugin;
+    use chrono::Utc;
+
+    // Test 4: Build dashboard stats with no plugins
+    #[tokio::test]
+    async fn test_build_dashboard_stats_empty() {
+        let mut mock_db = MockDatabase::new();
+        mock_db.expect_get_block_logs_count().returning(|| Ok(0));
+
+        let stats = build_dashboard_stats(&mock_db, &[], &None::<Arc<dyn CachePlugin>>).await;
+
+        assert_eq!(stats.total_requests, 0);
+        assert_eq!(stats.blocked_requests, 0);
+        assert_eq!(stats.security_sources_count, 0);
+    }
+
+    // Test 5: Build dashboard stats with security plugins
+    #[tokio::test]
+    async fn test_build_dashboard_stats_with_security_plugins() {
+        let mut mock_db = MockDatabase::new();
+        mock_db.expect_get_block_logs_count().returning(|| Ok(42));
+
+        let mut mock_plugin = MockSecuritySourcePlugin::new();
+        mock_plugin.expect_name().return_const("osv".to_string());
+        mock_plugin
+            .expect_supported_ecosystems()
+            .return_const(vec!["pypi".to_string()]);
+        mock_plugin.expect_sync_status().return_const(SyncStatus {
+            source: "osv".to_string(),
+            last_sync_at: Some(Utc::now()),
+            status: SyncStatusValue::Success,
+            records_count: 100,
+            error_message: None,
+        });
+
+        let plugins: Vec<Arc<dyn SecuritySourcePlugin>> = vec![Arc::new(mock_plugin)];
+        let stats = build_dashboard_stats(&mock_db, &plugins, &None::<Arc<dyn CachePlugin>>).await;
+
+        assert_eq!(stats.blocked_requests, 42);
+        assert_eq!(stats.security_sources_count, 1);
+        assert_eq!(stats.blocked_packages_count, 100);
+        assert_eq!(stats.security_sources.len(), 1);
+        assert_eq!(stats.security_sources[0].name, "osv");
+    }
+
+    // Test 6: Build dashboard stats with cache plugin
+    #[tokio::test]
+    async fn test_build_dashboard_stats_with_cache() {
+        let mut mock_db = MockDatabase::new();
+        mock_db.expect_get_block_logs_count().returning(|| Ok(0));
+
+        let mut mock_cache = MockCachePlugin::new();
+        mock_cache.expect_stats().returning(|| CacheStats {
+            hits: 80,
+            misses: 20,
+            total_size_bytes: 1024,
+            entries: 10,
+            evictions: 0,
+        });
+
+        let cache: Option<Arc<dyn CachePlugin>> = Some(Arc::new(mock_cache));
+        let stats = build_dashboard_stats(&mock_db, &[], &cache).await;
+
+        assert_eq!(stats.total_requests, 100);
+        assert!((stats.cache_hit_rate - 0.8).abs() < 0.001);
+    }
+
+    // Test 7: Get block logs
+    #[tokio::test]
+    async fn test_get_block_logs() {
+        let mut mock_db = MockDatabase::new();
+        mock_db.expect_get_block_logs().returning(|_, _| {
+            Ok(vec![
+                BlockLog::new("pypi", "pkg1", "1.0.0", "osv"),
+                BlockLog::new("cargo", "pkg2", "2.0.0", "openssf"),
+            ])
+        });
+        mock_db.expect_get_block_logs_count().returning(|| Ok(2));
+
+        let result = get_block_logs(&mock_db, 10, 0).await.unwrap();
+
+        assert_eq!(result.logs.len(), 2);
+        assert_eq!(result.total, 2);
+        assert_eq!(result.logs[0].ecosystem, "pypi");
+        assert_eq!(result.logs[1].ecosystem, "cargo");
+    }
+
+    // Test 8: Build security sources response
+    #[test]
+    fn test_build_security_sources_response() {
+        let mut mock_plugin = MockSecuritySourcePlugin::new();
+        mock_plugin.expect_name().return_const("osv".to_string());
+        mock_plugin
+            .expect_supported_ecosystems()
+            .return_const(vec!["pypi".to_string(), "cargo".to_string()]);
+        mock_plugin.expect_sync_status().return_const(SyncStatus {
+            source: "osv".to_string(),
+            last_sync_at: None,
+            status: SyncStatusValue::Pending,
+            records_count: 0,
+            error_message: None,
+        });
+
+        let plugins: Vec<Arc<dyn SecuritySourcePlugin>> = vec![Arc::new(mock_plugin)];
+        let response = build_security_sources_response(&plugins);
+
+        assert_eq!(response.sources.len(), 1);
+        assert_eq!(response.sources[0].name, "osv");
+        assert_eq!(response.sources[0].ecosystems.len(), 2);
+        assert_eq!(response.sources[0].status, "pending");
+    }
+
+    // Test 9: Get cache stats with plugin
+    #[tokio::test]
+    async fn test_get_cache_stats_with_plugin() {
+        let mut mock_cache = MockCachePlugin::new();
+        mock_cache
+            .expect_name()
+            .return_const("filesystem".to_string());
+        mock_cache.expect_stats().returning(|| CacheStats {
+            hits: 100,
+            misses: 50,
+            total_size_bytes: 2048,
+            entries: 25,
+            evictions: 0,
+        });
+
+        let cache: Option<Arc<dyn CachePlugin>> = Some(Arc::new(mock_cache));
+        let stats = get_cache_stats(&cache).await;
+
+        assert_eq!(stats.plugin, "filesystem");
+        assert_eq!(stats.hits, 100);
+        assert_eq!(stats.misses, 50);
+        assert_eq!(stats.total_size_bytes, 2048);
+        assert_eq!(stats.entries, 25);
+    }
+
+    // Test 10: Get cache stats without plugin
+    #[tokio::test]
+    async fn test_get_cache_stats_no_plugin() {
+        let cache: Option<Arc<dyn CachePlugin>> = None;
+        let stats = get_cache_stats(&cache).await;
+
+        assert_eq!(stats.plugin, "none");
+        assert_eq!(stats.hits, 0);
+    }
+
+    // Test 11: Clear cache with plugin
+    #[tokio::test]
+    async fn test_clear_cache_with_plugin() {
+        let mut mock_cache = MockCachePlugin::new();
+        mock_cache.expect_purge().returning(|| Ok(()));
+
+        let cache: Option<Arc<dyn CachePlugin>> = Some(Arc::new(mock_cache));
+        let result = clear_cache(&cache).await;
+
+        assert!(result.is_ok());
+    }
+
+    // Test 12: Clear cache without plugin
+    #[tokio::test]
+    async fn test_clear_cache_no_plugin() {
+        let cache: Option<Arc<dyn CachePlugin>> = None;
+        let result = clear_cache(&cache).await;
+
+        assert!(result.is_ok());
+    }
+}

--- a/src/api/handlers.rs
+++ b/src/api/handlers.rs
@@ -23,9 +23,12 @@ pub async fn build_dashboard_stats<D: Database>(
     database: &D,
     security_plugins: &[Arc<dyn SecuritySourcePlugin>],
     cache_plugin: &Option<Arc<dyn CachePlugin>>,
-) -> DashboardStats {
+) -> Result<DashboardStats, String> {
     // Get block logs count for blocked_requests
-    let blocked_requests = database.get_block_logs_count().await.unwrap_or(0);
+    let blocked_requests = database
+        .get_block_logs_count()
+        .await
+        .map_err(|e| e.to_string())?;
 
     // Get cache stats if available
     let (cache_hit_rate, total_requests) = if let Some(cache) = cache_plugin {
@@ -59,14 +62,14 @@ pub async fn build_dashboard_stats<D: Database>(
     // Calculate total blocked packages
     let blocked_packages_count: u64 = security_sources.iter().map(|s| s.records_count).sum();
 
-    DashboardStats {
+    Ok(DashboardStats {
         total_requests,
         blocked_requests,
         cache_hit_rate,
         security_sources_count: security_plugins.len(),
         blocked_packages_count,
         security_sources,
-    }
+    })
 }
 
 /// Get block logs from database
@@ -183,7 +186,9 @@ mod tests {
         let mut mock_db = MockDatabase::new();
         mock_db.expect_get_block_logs_count().returning(|| Ok(0));
 
-        let stats = build_dashboard_stats(&mock_db, &[], &None::<Arc<dyn CachePlugin>>).await;
+        let stats = build_dashboard_stats(&mock_db, &[], &None::<Arc<dyn CachePlugin>>)
+            .await
+            .unwrap();
 
         assert_eq!(stats.total_requests, 0);
         assert_eq!(stats.blocked_requests, 0);
@@ -210,7 +215,9 @@ mod tests {
         });
 
         let plugins: Vec<Arc<dyn SecuritySourcePlugin>> = vec![Arc::new(mock_plugin)];
-        let stats = build_dashboard_stats(&mock_db, &plugins, &None::<Arc<dyn CachePlugin>>).await;
+        let stats = build_dashboard_stats(&mock_db, &plugins, &None::<Arc<dyn CachePlugin>>)
+            .await
+            .unwrap();
 
         assert_eq!(stats.blocked_requests, 42);
         assert_eq!(stats.security_sources_count, 1);
@@ -235,7 +242,7 @@ mod tests {
         });
 
         let cache: Option<Arc<dyn CachePlugin>> = Some(Arc::new(mock_cache));
-        let stats = build_dashboard_stats(&mock_db, &[], &cache).await;
+        let stats = build_dashboard_stats(&mock_db, &[], &cache).await.unwrap();
 
         assert_eq!(stats.total_requests, 100);
         assert!((stats.cache_hit_rate - 0.8).abs() < 0.001);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,8 @@
 
 pub mod types;
 pub mod handlers;
+#[cfg(feature = "swagger-gen")]
+pub mod openapi;
 
 pub use types::*;
 pub use handlers::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,10 +3,10 @@
 //! This module contains API type definitions and business logic
 //! that are independent of the webui feature flag.
 
-pub mod types;
 pub mod handlers;
 #[cfg(feature = "swagger-gen")]
 pub mod openapi;
+pub mod types;
 
-pub use types::*;
 pub use handlers::*;
+pub use types::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,10 @@
+//! REST API types and handlers
+//!
+//! This module contains API type definitions and business logic
+//! that are independent of the webui feature flag.
+
+pub mod types;
+pub mod handlers;
+
+pub use types::*;
+pub use handlers::*;

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -65,13 +65,20 @@ impl utoipa::Modify for SecurityAddon {
             utoipa::openapi::ServerBuilder::new()
                 .url("{scheme}://{host}:{port}")
                 .description(Some("registry-firewall instance"))
-                .parameter("scheme", utoipa::openapi::ServerVariableBuilder::new()
-                    .default_value("http")
-                    .enum_values(Some(["http", "https"])))
-                .parameter("host", utoipa::openapi::ServerVariableBuilder::new()
-                    .default_value("localhost"))
-                .parameter("port", utoipa::openapi::ServerVariableBuilder::new()
-                    .default_value("8080"))
+                .parameter(
+                    "scheme",
+                    utoipa::openapi::ServerVariableBuilder::new()
+                        .default_value("http")
+                        .enum_values(Some(["http", "https"])),
+                )
+                .parameter(
+                    "host",
+                    utoipa::openapi::ServerVariableBuilder::new().default_value("localhost"),
+                )
+                .parameter(
+                    "port",
+                    utoipa::openapi::ServerVariableBuilder::new().default_value("8080"),
+                )
                 .build(),
         ]);
 

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -61,26 +61,24 @@ impl utoipa::Modify for SecurityAddon {
         openapi.info.version = env!("CARGO_PKG_VERSION").to_string();
 
         // Add server definition with placeholder
-        openapi.servers = Some(vec![
-            utoipa::openapi::ServerBuilder::new()
-                .url("{scheme}://{host}:{port}")
-                .description(Some("registry-firewall instance"))
-                .parameter(
-                    "scheme",
-                    utoipa::openapi::ServerVariableBuilder::new()
-                        .default_value("http")
-                        .enum_values(Some(["http", "https"])),
-                )
-                .parameter(
-                    "host",
-                    utoipa::openapi::ServerVariableBuilder::new().default_value("localhost"),
-                )
-                .parameter(
-                    "port",
-                    utoipa::openapi::ServerVariableBuilder::new().default_value("8080"),
-                )
-                .build(),
-        ]);
+        openapi.servers = Some(vec![utoipa::openapi::ServerBuilder::new()
+            .url("{scheme}://{host}:{port}")
+            .description(Some("registry-firewall instance"))
+            .parameter(
+                "scheme",
+                utoipa::openapi::ServerVariableBuilder::new()
+                    .default_value("http")
+                    .enum_values(Some(["http", "https"])),
+            )
+            .parameter(
+                "host",
+                utoipa::openapi::ServerVariableBuilder::new().default_value("localhost"),
+            )
+            .parameter(
+                "port",
+                utoipa::openapi::ServerVariableBuilder::new().default_value("8080"),
+            )
+            .build()]);
 
         // Add security schemes
         let components = openapi.components.get_or_insert_with(Default::default);

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -7,7 +7,6 @@ use utoipa::OpenApi;
 
 use crate::api::types::*;
 use crate::models::CustomRule;
-use crate::server::router::CreateTokenApiRequest;
 
 #[derive(OpenApi)]
 #[openapi(

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -8,8 +8,8 @@ use utoipa::OpenApi;
 use crate::api::types::{
     BlockLogEntry, BlockLogsQuery, BlockLogsResponse, CacheClearResponse, CacheStatsResponse,
     CreateTokenApiRequest, CreateTokenResponse, DashboardStats, ErrorResponse, MessageResponse,
-    RulesResponse, SecuritySourceInfo, SecuritySourceSummary, SecuritySourcesResponse,
-    SyncTriggerResponse, TokenInfo, TokensResponse,
+    RulesResponse, SecuritySourceInfo, SecuritySourcesResponse, SyncTriggerResponse, TokenInfo,
+    TokensResponse,
 };
 use crate::models::CustomRule;
 
@@ -37,7 +37,7 @@ use crate::models::CustomRule;
     ),
     components(
         schemas(
-            DashboardStats, SecuritySourceSummary, BlockLogsQuery, BlockLogsResponse,
+            DashboardStats, BlockLogsQuery, BlockLogsResponse,
             BlockLogEntry, SecuritySourcesResponse, SecuritySourceInfo, SyncTriggerResponse,
             CacheStatsResponse, CacheClearResponse, RulesResponse, TokensResponse,
             TokenInfo, CreateTokenResponse, MessageResponse, ErrorResponse,

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -5,7 +5,12 @@
 
 use utoipa::OpenApi;
 
-use crate::api::types::*;
+use crate::api::types::{
+    BlockLogEntry, BlockLogsQuery, BlockLogsResponse, CacheClearResponse, CacheStatsResponse,
+    CreateTokenApiRequest, CreateTokenResponse, DashboardStats, ErrorResponse, MessageResponse,
+    RulesResponse, SecuritySourceInfo, SecuritySourceSummary, SecuritySourcesResponse,
+    SyncTriggerResponse, TokenInfo, TokensResponse,
+};
 use crate::models::CustomRule;
 
 #[derive(OpenApi)]
@@ -35,7 +40,7 @@ use crate::models::CustomRule;
             DashboardStats, SecuritySourceSummary, BlockLogsQuery, BlockLogsResponse,
             BlockLogEntry, SecuritySourcesResponse, SecuritySourceInfo, SyncTriggerResponse,
             CacheStatsResponse, CacheClearResponse, RulesResponse, TokensResponse,
-            TokenInfo, CreateTokenRequest, CreateTokenResponse, MessageResponse, ErrorResponse,
+            TokenInfo, CreateTokenResponse, MessageResponse, ErrorResponse,
             CustomRule, CreateTokenApiRequest,
         )
     ),

--- a/src/api/openapi.rs
+++ b/src/api/openapi.rs
@@ -1,0 +1,130 @@
+//! OpenAPI specification generation
+//!
+//! This module provides the ApiDoc struct for generating OpenAPI/Swagger specifications.
+//! Only compiled when the "swagger-gen" feature is enabled.
+
+use utoipa::OpenApi;
+
+use crate::api::types::*;
+use crate::models::CustomRule;
+use crate::server::router::CreateTokenApiRequest;
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "registry-firewall API",
+        description = "A unified registry proxy that protects development environments from software supply chain attacks",
+    ),
+    paths(
+        crate::server::router::api_dashboard_handler,
+        crate::server::router::api_blocks_handler,
+        crate::server::router::api_security_sources_handler,
+        crate::server::router::api_trigger_sync_handler,
+        crate::server::router::api_cache_stats_handler,
+        crate::server::router::api_cache_clear_handler,
+        crate::server::router::api_list_rules_handler,
+        crate::server::router::api_create_rule_handler,
+        crate::server::router::api_get_rule_handler,
+        crate::server::router::api_update_rule_handler,
+        crate::server::router::api_delete_rule_handler,
+        crate::server::router::api_list_tokens_handler,
+        crate::server::router::api_create_token_handler,
+        crate::server::router::api_delete_token_handler,
+    ),
+    components(
+        schemas(
+            DashboardStats, SecuritySourceSummary, BlockLogsQuery, BlockLogsResponse,
+            BlockLogEntry, SecuritySourcesResponse, SecuritySourceInfo, SyncTriggerResponse,
+            CacheStatsResponse, CacheClearResponse, RulesResponse, TokensResponse,
+            TokenInfo, CreateTokenRequest, CreateTokenResponse, MessageResponse, ErrorResponse,
+            CustomRule, CreateTokenApiRequest,
+        )
+    ),
+    modifiers(&SecurityAddon),
+    tags(
+        (name = "dashboard", description = "Dashboard statistics"),
+        (name = "blocks", description = "Block log management"),
+        (name = "security-sources", description = "Security source management"),
+        (name = "cache", description = "Cache management"),
+        (name = "rules", description = "Custom block rule management"),
+        (name = "tokens", description = "API token management"),
+    )
+)]
+pub struct ApiDoc;
+
+/// Security schemes modifier for OpenAPI spec
+struct SecurityAddon;
+
+impl utoipa::Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        // Set version from Cargo.toml
+        openapi.info.version = env!("CARGO_PKG_VERSION").to_string();
+
+        // Add server definition with placeholder
+        openapi.servers = Some(vec![
+            utoipa::openapi::ServerBuilder::new()
+                .url("{scheme}://{host}:{port}")
+                .description(Some("registry-firewall instance"))
+                .parameter("scheme", utoipa::openapi::ServerVariableBuilder::new()
+                    .default_value("http")
+                    .enum_values(Some(["http", "https"])))
+                .parameter("host", utoipa::openapi::ServerVariableBuilder::new()
+                    .default_value("localhost"))
+                .parameter("port", utoipa::openapi::ServerVariableBuilder::new()
+                    .default_value("8080"))
+                .build(),
+        ]);
+
+        // Add security schemes
+        let components = openapi.components.get_or_insert_with(Default::default);
+        components.add_security_scheme(
+            "bearer_token",
+            utoipa::openapi::security::SecurityScheme::Http(
+                utoipa::openapi::security::HttpBuilder::new()
+                    .scheme(utoipa::openapi::security::HttpAuthScheme::Bearer)
+                    .bearer_format("token")
+                    .build(),
+            ),
+        );
+        components.add_security_scheme(
+            "basic_auth",
+            utoipa::openapi::security::SecurityScheme::Http(
+                utoipa::openapi::security::HttpBuilder::new()
+                    .scheme(utoipa::openapi::security::HttpAuthScheme::Basic)
+                    .build(),
+            ),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apidoc_generates_openapi() {
+        let openapi = ApiDoc::openapi();
+        let json = openapi.to_pretty_json().unwrap();
+        assert!(!json.is_empty());
+    }
+
+    #[test]
+    fn test_apidoc_version_matches_cargo() {
+        let openapi = ApiDoc::openapi();
+        assert_eq!(openapi.info.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn test_apidoc_security_schemes() {
+        let openapi = ApiDoc::openapi();
+        let components = openapi.components.unwrap();
+        assert!(components.security_schemes.contains_key("bearer_token"));
+        assert!(components.security_schemes.contains_key("basic_auth"));
+    }
+
+    #[test]
+    fn test_apidoc_has_paths() {
+        let openapi = ApiDoc::openapi();
+        assert!(!openapi.paths.paths.is_empty());
+    }
+}

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -80,9 +80,7 @@ pub struct BlockLogsQuery {
 impl BlockLogsQuery {
     /// Normalized limit, clamped to [1, MAX_PAGE_LIMIT]
     pub fn normalized_limit(&self) -> u32 {
-        self.limit
-            .unwrap_or(DEFAULT_PAGE_LIMIT)
-            .min(MAX_PAGE_LIMIT)
+        self.limit.unwrap_or(DEFAULT_PAGE_LIMIT).min(MAX_PAGE_LIMIT)
     }
 
     /// Normalized offset, defaults to 0

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -80,7 +80,9 @@ pub struct BlockLogsQuery {
 impl BlockLogsQuery {
     /// Normalized limit, clamped to [1, MAX_PAGE_LIMIT]
     pub fn normalized_limit(&self) -> u32 {
-        self.limit.unwrap_or(DEFAULT_PAGE_LIMIT).clamp(1, MAX_PAGE_LIMIT)
+        self.limit
+            .unwrap_or(DEFAULT_PAGE_LIMIT)
+            .clamp(1, MAX_PAGE_LIMIT)
     }
 
     /// Normalized offset, defaults to 0

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -80,7 +80,10 @@ pub struct BlockLogsQuery {
 impl BlockLogsQuery {
     /// Normalized limit, clamped to [1, MAX_PAGE_LIMIT]
     pub fn normalized_limit(&self) -> u32 {
-        self.limit.unwrap_or(DEFAULT_PAGE_LIMIT).min(MAX_PAGE_LIMIT)
+        self.limit
+            .unwrap_or(DEFAULT_PAGE_LIMIT)
+            .max(1)
+            .min(MAX_PAGE_LIMIT)
     }
 
     /// Normalized offset, defaults to 0
@@ -500,5 +503,30 @@ mod tests {
         assert!(debug_output.contains("<redacted>"));
         assert!(debug_output.contains("test-id"));
         assert!(debug_output.contains("test-name"));
+    }
+
+    // Test: BlockLogsQuery normalized_limit boundary conditions
+    #[test]
+    fn test_normalized_limit_bounds() {
+        // Zero clamped to 1
+        let q = BlockLogsQuery {
+            limit: Some(0),
+            offset: None,
+        };
+        assert_eq!(q.normalized_limit(), 1);
+
+        // Over MAX clamped down
+        let q = BlockLogsQuery {
+            limit: Some(MAX_PAGE_LIMIT + 1),
+            offset: None,
+        };
+        assert_eq!(q.normalized_limit(), MAX_PAGE_LIMIT);
+
+        // Default when None
+        let q = BlockLogsQuery {
+            limit: None,
+            offset: None,
+        };
+        assert_eq!(q.normalized_limit(), DEFAULT_PAGE_LIMIT);
     }
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -103,10 +103,19 @@ pub struct BlockLogEntry {
     pub source: String,
     /// Block reason
     pub reason: Option<String>,
-    /// Client IP (masked for privacy, e.g. "192.168.x.x")
-    pub client_ip: Option<String>,
+    /// Client IP (always masked for privacy, e.g. "192.168.x.x").
+    /// Use `BlockLogEntry::from(BlockLog)` to construct; raw IPs are auto-masked.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_ip: Option<String>,
     /// Timestamp
     pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+impl BlockLogEntry {
+    /// Get the masked client IP
+    pub fn client_ip(&self) -> Option<&str> {
+        self.client_ip.as_deref()
+    }
 }
 
 /// Mask an IP address for privacy (e.g., "192.168.1.100" -> "192.168.x.x")
@@ -374,17 +383,14 @@ mod tests {
     // Test 14: BlockLogsResponse serialization
     #[test]
     fn test_block_logs_response_serialization() {
+        let mut log = BlockLog::new("pypi", "malicious", "1.0.0", "osv");
+        log.reason = Some("CVE-2024-1234".to_string());
+        log.client_ip = Some("192.168.1.1".to_string());
+        let entry = BlockLogEntry::from(log);
+        // Verify IP is masked
+        assert_eq!(entry.client_ip(), Some("192.168.x.x"));
         let response = BlockLogsResponse {
-            logs: vec![BlockLogEntry {
-                id: Some(1),
-                ecosystem: "pypi".to_string(),
-                package: "malicious".to_string(),
-                version: "1.0.0".to_string(),
-                source: "osv".to_string(),
-                reason: Some("CVE-2024-1234".to_string()),
-                client_ip: Some("192.168.1.1".to_string()),
-                timestamp: Utc::now(),
-            }],
+            logs: vec![entry],
             total: 1,
         };
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -80,10 +80,7 @@ pub struct BlockLogsQuery {
 impl BlockLogsQuery {
     /// Normalized limit, clamped to [1, MAX_PAGE_LIMIT]
     pub fn normalized_limit(&self) -> u32 {
-        self.limit
-            .unwrap_or(DEFAULT_PAGE_LIMIT)
-            .max(1)
-            .min(MAX_PAGE_LIMIT)
+        self.limit.unwrap_or(DEFAULT_PAGE_LIMIT).clamp(1, MAX_PAGE_LIMIT)
     }
 
     /// Normalized offset, defaults to 0

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -129,7 +129,10 @@ fn mask_ip(ip: &str) -> String {
         Ok(IpAddr::V6(addr)) => {
             let segments = addr.segments();
             let half = segments.len() / 2;
-            let prefix: Vec<String> = segments[..half].iter().map(|s| format!("{:x}", s)).collect();
+            let prefix: Vec<String> = segments[..half]
+                .iter()
+                .map(|s| format!("{:x}", s))
+                .collect();
             let masked_count = segments.len() - half;
             let mask = vec!["x"; masked_count].join(":");
             format!("{}:{}", prefix.join(":"), mask)

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -251,7 +251,7 @@ pub struct TokenInfo {
 
 impl From<&Token> for TokenInfo {
     fn from(token: &Token) -> Self {
-        // Create masked token prefix from ID (tokens start with rf_)
+        // Create masked token prefix: "rf_" + first N chars of ID + "***"
         let prefix = format!(
             "rf_{}***",
             &token.id[..TOKEN_MASK_PREFIX_LENGTH.min(token.id.len())]

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -296,6 +296,15 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+/// Create token API request
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
+#[derive(Debug, Deserialize)]
+pub struct CreateTokenApiRequest {
+    pub name: String,
+    pub allowed_ecosystems: Option<Vec<String>>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
 // =============================================================================
 // Tests
 // =============================================================================

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,23 +1,10 @@
-//! Web UI API handlers
+//! API type definitions
 //!
-//! This module provides REST API endpoints for the Web UI.
-//! All endpoints require authentication unless otherwise noted.
-//!
-//! # Security Notes
-//!
-//! - Token values are never logged and only returned once at creation time
-//! - Internal error details are logged but not exposed to clients
-//! - All endpoints require authentication via the auth middleware
-//! - Destructive operations log the action for audit purposes
+//! This module contains request/response types and constants for the REST API.
 
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
-use crate::database::Database;
-use crate::models::{BlockLog, CustomRule, Token};
-use crate::plugins::cache::traits::CachePlugin;
-use crate::plugins::security::traits::SecuritySourcePlugin;
-use crate::sync::ManualSyncHandle;
+use crate::models::{BlockLog, Token};
 
 // =============================================================================
 // Constants
@@ -204,7 +191,7 @@ pub struct CacheClearResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RulesResponse {
     /// List of custom rules
-    pub rules: Vec<CustomRule>,
+    pub rules: Vec<crate::models::CustomRule>,
 }
 
 /// Token list response
@@ -293,166 +280,14 @@ pub struct ErrorResponse {
 }
 
 // =============================================================================
-// API Functions
-// =============================================================================
-
-/// Build dashboard statistics from application state
-pub async fn build_dashboard_stats<D: Database>(
-    database: &D,
-    security_plugins: &[Arc<dyn SecuritySourcePlugin>],
-    cache_plugin: &Option<Arc<dyn CachePlugin>>,
-) -> DashboardStats {
-    // Get block logs count for blocked_requests
-    let blocked_requests = database.get_block_logs_count().await.unwrap_or(0);
-
-    // Get cache stats if available
-    let (cache_hit_rate, total_requests) = if let Some(cache) = cache_plugin {
-        let stats = cache.stats().await;
-        let total = stats.hits + stats.misses;
-        let hit_rate = if total > 0 {
-            stats.hits as f64 / total as f64
-        } else {
-            0.0
-        };
-        (hit_rate, total)
-    } else {
-        (0.0, 0)
-    };
-
-    // Build security source summaries
-    let security_sources: Vec<SecuritySourceSummary> = security_plugins
-        .iter()
-        .map(|p| {
-            let status = p.sync_status();
-            SecuritySourceSummary {
-                name: p.name().to_string(),
-                ecosystems: p.supported_ecosystems().to_vec(),
-                last_sync: status.last_sync_at,
-                status: status.status.to_string(),
-                records_count: status.records_count,
-            }
-        })
-        .collect();
-
-    // Calculate total blocked packages
-    let blocked_packages_count: u64 = security_sources.iter().map(|s| s.records_count).sum();
-
-    DashboardStats {
-        total_requests,
-        blocked_requests,
-        cache_hit_rate,
-        security_sources_count: security_plugins.len(),
-        blocked_packages_count,
-        security_sources,
-    }
-}
-
-/// Get block logs from database
-pub async fn get_block_logs<D: Database>(
-    database: &D,
-    limit: u32,
-    offset: u32,
-) -> Result<BlockLogsResponse, String> {
-    let logs = database
-        .get_block_logs(limit, offset)
-        .await
-        .map_err(|e| e.to_string())?;
-
-    let total = database
-        .get_block_logs_count()
-        .await
-        .map_err(|e| e.to_string())?;
-
-    Ok(BlockLogsResponse {
-        logs: logs.into_iter().map(BlockLogEntry::from).collect(),
-        total,
-    })
-}
-
-/// Build security sources response
-pub fn build_security_sources_response(
-    security_plugins: &[Arc<dyn SecuritySourcePlugin>],
-) -> SecuritySourcesResponse {
-    let sources: Vec<SecuritySourceInfo> = security_plugins
-        .iter()
-        .map(|p| {
-            let status = p.sync_status();
-            SecuritySourceInfo {
-                name: p.name().to_string(),
-                ecosystems: p.supported_ecosystems().to_vec(),
-                last_sync: status.last_sync_at,
-                status: status.status.to_string(),
-                records_count: status.records_count,
-            }
-        })
-        .collect();
-
-    SecuritySourcesResponse { sources }
-}
-
-/// Trigger sync for a security source
-pub async fn trigger_sync(
-    sync_handle: &ManualSyncHandle,
-    source_name: &str,
-) -> SyncTriggerResponse {
-    match sync_handle.trigger_sync(source_name).await {
-        Ok(result) => SyncTriggerResponse {
-            message: format!("Sync completed for {}", source_name),
-            success: true,
-            records_updated: Some(result.records_updated),
-        },
-        Err(e) => SyncTriggerResponse {
-            message: format!("Sync failed for {}: {}", source_name, e),
-            success: false,
-            records_updated: None,
-        },
-    }
-}
-
-/// Get cache statistics
-pub async fn get_cache_stats(cache_plugin: &Option<Arc<dyn CachePlugin>>) -> CacheStatsResponse {
-    if let Some(cache) = cache_plugin {
-        let stats = cache.stats().await;
-        CacheStatsResponse {
-            plugin: cache.name().to_string(),
-            hits: stats.hits,
-            misses: stats.misses,
-            total_size_bytes: stats.total_size_bytes,
-            entries: stats.entries,
-        }
-    } else {
-        CacheStatsResponse {
-            plugin: "none".to_string(),
-            hits: 0,
-            misses: 0,
-            total_size_bytes: 0,
-            entries: 0,
-        }
-    }
-}
-
-/// Clear cache
-pub async fn clear_cache(cache_plugin: &Option<Arc<dyn CachePlugin>>) -> Result<(), String> {
-    if let Some(cache) = cache_plugin {
-        cache.purge().await.map_err(|e| e.to_string())
-    } else {
-        Ok(())
-    }
-}
-
-// =============================================================================
 // Tests
 // =============================================================================
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::database::MockDatabase;
-    use crate::models::SyncStatus;
-    use crate::models::{BlockLog, SyncStatusValue};
-    use crate::plugins::cache::traits::MockCachePlugin;
-    use crate::plugins::cache::CacheStats;
-    use crate::plugins::security::traits::MockSecuritySourcePlugin;
+    use crate::models::BlockLog;
+    use crate::models::Token;
     use chrono::Utc;
 
     // Test 1: DashboardStats default values
@@ -487,171 +322,6 @@ mod tests {
 
         assert_eq!(info.id, "test-id");
         assert_eq!(info.name, "test-token");
-    }
-
-    // Test 4: Build dashboard stats with no plugins
-    #[tokio::test]
-    async fn test_build_dashboard_stats_empty() {
-        let mut mock_db = MockDatabase::new();
-        mock_db.expect_get_block_logs_count().returning(|| Ok(0));
-
-        let stats = build_dashboard_stats(&mock_db, &[], &None::<Arc<dyn CachePlugin>>).await;
-
-        assert_eq!(stats.total_requests, 0);
-        assert_eq!(stats.blocked_requests, 0);
-        assert_eq!(stats.security_sources_count, 0);
-    }
-
-    // Test 5: Build dashboard stats with security plugins
-    #[tokio::test]
-    async fn test_build_dashboard_stats_with_security_plugins() {
-        let mut mock_db = MockDatabase::new();
-        mock_db.expect_get_block_logs_count().returning(|| Ok(42));
-
-        let mut mock_plugin = MockSecuritySourcePlugin::new();
-        mock_plugin.expect_name().return_const("osv".to_string());
-        mock_plugin
-            .expect_supported_ecosystems()
-            .return_const(vec!["pypi".to_string()]);
-        mock_plugin.expect_sync_status().return_const(SyncStatus {
-            source: "osv".to_string(),
-            last_sync_at: Some(Utc::now()),
-            status: SyncStatusValue::Success,
-            records_count: 100,
-            error_message: None,
-        });
-
-        let plugins: Vec<Arc<dyn SecuritySourcePlugin>> = vec![Arc::new(mock_plugin)];
-        let stats = build_dashboard_stats(&mock_db, &plugins, &None::<Arc<dyn CachePlugin>>).await;
-
-        assert_eq!(stats.blocked_requests, 42);
-        assert_eq!(stats.security_sources_count, 1);
-        assert_eq!(stats.blocked_packages_count, 100);
-        assert_eq!(stats.security_sources.len(), 1);
-        assert_eq!(stats.security_sources[0].name, "osv");
-    }
-
-    // Test 6: Build dashboard stats with cache plugin
-    #[tokio::test]
-    async fn test_build_dashboard_stats_with_cache() {
-        let mut mock_db = MockDatabase::new();
-        mock_db.expect_get_block_logs_count().returning(|| Ok(0));
-
-        let mut mock_cache = MockCachePlugin::new();
-        mock_cache.expect_stats().returning(|| CacheStats {
-            hits: 80,
-            misses: 20,
-            total_size_bytes: 1024,
-            entries: 10,
-            evictions: 0,
-        });
-
-        let cache: Option<Arc<dyn CachePlugin>> = Some(Arc::new(mock_cache));
-        let stats = build_dashboard_stats(&mock_db, &[], &cache).await;
-
-        assert_eq!(stats.total_requests, 100);
-        assert!((stats.cache_hit_rate - 0.8).abs() < 0.001);
-    }
-
-    // Test 7: Get block logs
-    #[tokio::test]
-    async fn test_get_block_logs() {
-        let mut mock_db = MockDatabase::new();
-        mock_db.expect_get_block_logs().returning(|_, _| {
-            Ok(vec![
-                BlockLog::new("pypi", "pkg1", "1.0.0", "osv"),
-                BlockLog::new("cargo", "pkg2", "2.0.0", "openssf"),
-            ])
-        });
-        mock_db.expect_get_block_logs_count().returning(|| Ok(2));
-
-        let result = get_block_logs(&mock_db, 10, 0).await.unwrap();
-
-        assert_eq!(result.logs.len(), 2);
-        assert_eq!(result.total, 2);
-        assert_eq!(result.logs[0].ecosystem, "pypi");
-        assert_eq!(result.logs[1].ecosystem, "cargo");
-    }
-
-    // Test 8: Build security sources response
-    #[test]
-    fn test_build_security_sources_response() {
-        let mut mock_plugin = MockSecuritySourcePlugin::new();
-        mock_plugin.expect_name().return_const("osv".to_string());
-        mock_plugin
-            .expect_supported_ecosystems()
-            .return_const(vec!["pypi".to_string(), "cargo".to_string()]);
-        mock_plugin.expect_sync_status().return_const(SyncStatus {
-            source: "osv".to_string(),
-            last_sync_at: None,
-            status: SyncStatusValue::Pending,
-            records_count: 0,
-            error_message: None,
-        });
-
-        let plugins: Vec<Arc<dyn SecuritySourcePlugin>> = vec![Arc::new(mock_plugin)];
-        let response = build_security_sources_response(&plugins);
-
-        assert_eq!(response.sources.len(), 1);
-        assert_eq!(response.sources[0].name, "osv");
-        assert_eq!(response.sources[0].ecosystems.len(), 2);
-        assert_eq!(response.sources[0].status, "pending");
-    }
-
-    // Test 9: Get cache stats with plugin
-    #[tokio::test]
-    async fn test_get_cache_stats_with_plugin() {
-        let mut mock_cache = MockCachePlugin::new();
-        mock_cache
-            .expect_name()
-            .return_const("filesystem".to_string());
-        mock_cache.expect_stats().returning(|| CacheStats {
-            hits: 100,
-            misses: 50,
-            total_size_bytes: 2048,
-            entries: 25,
-            evictions: 0,
-        });
-
-        let cache: Option<Arc<dyn CachePlugin>> = Some(Arc::new(mock_cache));
-        let stats = get_cache_stats(&cache).await;
-
-        assert_eq!(stats.plugin, "filesystem");
-        assert_eq!(stats.hits, 100);
-        assert_eq!(stats.misses, 50);
-        assert_eq!(stats.total_size_bytes, 2048);
-        assert_eq!(stats.entries, 25);
-    }
-
-    // Test 10: Get cache stats without plugin
-    #[tokio::test]
-    async fn test_get_cache_stats_no_plugin() {
-        let cache: Option<Arc<dyn CachePlugin>> = None;
-        let stats = get_cache_stats(&cache).await;
-
-        assert_eq!(stats.plugin, "none");
-        assert_eq!(stats.hits, 0);
-    }
-
-    // Test 11: Clear cache with plugin
-    #[tokio::test]
-    async fn test_clear_cache_with_plugin() {
-        let mut mock_cache = MockCachePlugin::new();
-        mock_cache.expect_purge().returning(|| Ok(()));
-
-        let cache: Option<Arc<dyn CachePlugin>> = Some(Arc::new(mock_cache));
-        let result = clear_cache(&cache).await;
-
-        assert!(result.is_ok());
-    }
-
-    // Test 12: Clear cache without plugin
-    #[tokio::test]
-    async fn test_clear_cache_no_plugin() {
-        let cache: Option<Arc<dyn CachePlugin>> = None;
-        let result = clear_cache(&cache).await;
-
-        assert!(result.is_ok());
     }
 
     // Test 13: DashboardStats serialization

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -120,21 +120,21 @@ impl BlockLogEntry {
 
 /// Mask an IP address for privacy (e.g., "192.168.1.100" -> "192.168.x.x")
 fn mask_ip(ip: &str) -> String {
-    if let Some(dot_pos) = ip.find('.') {
-        if let Some(second_dot) = ip[dot_pos + 1..].find('.') {
-            let prefix = &ip[..dot_pos + 1 + second_dot];
-            return format!("{}.x.x", prefix);
-        }
+    // Strict IPv4 validation: exactly 4 octets, each 0-255
+    let parts: Vec<&str> = ip.split('.').collect();
+    if parts.len() == 4 && parts.iter().all(|p| p.parse::<u8>().is_ok()) {
+        return format!("{}.{}.x.x", parts[0], parts[1]);
     }
-    // IPv6 or unparseable: mask last half of segments
+    // IPv6: mask last half of segments
     if ip.contains(':') {
-        let parts: Vec<&str> = ip.split(':').collect();
-        let half = parts.len() / 2;
-        let prefix: Vec<&str> = parts[..half].to_vec();
-        let masked_count = parts.len() - half;
+        let segments: Vec<&str> = ip.split(':').collect();
+        let half = segments.len() / 2;
+        let prefix: Vec<&str> = segments[..half].to_vec();
+        let masked_count = segments.len() - half;
         let mask = vec!["x"; masked_count].join(":");
         return format!("{}:{}", prefix.join(":"), mask);
     }
+    // Unparseable: fully mask
     "x.x.x.x".to_string()
 }
 
@@ -270,7 +270,7 @@ impl From<&Token> for TokenInfo {
 
 /// Create token response
 #[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct CreateTokenResponse {
     /// Token ID
     pub id: String,
@@ -282,6 +282,18 @@ pub struct CreateTokenResponse {
     pub created_at: chrono::DateTime<chrono::Utc>,
     /// Expires at
     pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl std::fmt::Debug for CreateTokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CreateTokenResponse")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("token", &"<redacted>")
+            .field("created_at", &self.created_at)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
 }
 
 /// Generic message response

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -77,6 +77,20 @@ pub struct BlockLogsQuery {
     pub offset: Option<u32>,
 }
 
+impl BlockLogsQuery {
+    /// Normalized limit, clamped to [1, MAX_PAGE_LIMIT]
+    pub fn normalized_limit(&self) -> u32 {
+        self.limit
+            .unwrap_or(DEFAULT_PAGE_LIMIT)
+            .min(MAX_PAGE_LIMIT)
+    }
+
+    /// Normalized offset, defaults to 0
+    pub fn normalized_offset(&self) -> u32 {
+        self.offset.unwrap_or(0)
+    }
+}
+
 /// Block logs response
 #[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -459,6 +473,15 @@ mod tests {
         let masked = mask_ip("::1");
         // ::1 expands to 0:0:0:0:0:0:0:1, first half preserved, last half masked
         assert!(masked.starts_with("0:0:0:0:"));
+        assert!(masked.ends_with(":x:x:x:x"));
+    }
+
+    // Test: mask_ip with IPv4-mapped IPv6 form
+    #[test]
+    fn test_mask_ip_ipv4_mapped_ipv6() {
+        let masked = mask_ip("::ffff:192.0.2.128");
+        // IPv4-mapped IPv6 should not leak raw IPv4 dotted notation
+        assert!(!masked.contains("192.0.2.128"));
         assert!(masked.ends_with(":x:x:x:x"));
     }
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -117,12 +117,14 @@ fn mask_ip(ip: &str) -> String {
             return format!("{}.x.x", prefix);
         }
     }
-    // IPv6 or unparseable: mask last half
+    // IPv6 or unparseable: mask last half of segments
     if ip.contains(':') {
         let parts: Vec<&str> = ip.split(':').collect();
         let half = parts.len() / 2;
         let prefix: Vec<&str> = parts[..half].to_vec();
-        return format!("{}:x:x:x", prefix.join(":"));
+        let masked_count = parts.len() - half;
+        let mask = vec!["x"; masked_count].join(":");
+        return format!("{}:{}", prefix.join(":"), mask);
     }
     "x.x.x.x".to_string()
 }
@@ -406,5 +408,27 @@ mod tests {
         let deserialized: CacheStatsResponse = serde_json::from_str(&json).unwrap();
 
         assert_eq!(response, deserialized);
+    }
+
+    // Test: mask_ip with IPv4 addresses
+    #[test]
+    fn test_mask_ip_ipv4() {
+        assert_eq!(mask_ip("192.168.1.100"), "192.168.x.x");
+        assert_eq!(mask_ip("10.0.0.1"), "10.0.x.x");
+        assert_eq!(mask_ip("172.16.254.3"), "172.16.x.x");
+    }
+
+    // Test: mask_ip with IPv6 addresses
+    #[test]
+    fn test_mask_ip_ipv6() {
+        let masked = mask_ip("2001:db8:85a3:8d3:1319:8a2e:370:7348");
+        assert!(masked.starts_with("2001:db8:85a3:8d3:"));
+        assert!(masked.ends_with(":x:x:x:x"));
+    }
+
+    // Test: mask_ip with invalid input
+    #[test]
+    fn test_mask_ip_invalid() {
+        assert_eq!(mask_ip("invalid"), "x.x.x.x");
     }
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -252,18 +252,6 @@ impl From<&Token> for TokenInfo {
     }
 }
 
-/// Create token request
-#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, Deserialize)]
-pub struct CreateTokenRequest {
-    /// Token name
-    pub name: String,
-    /// Allowed ecosystems
-    pub allowed_ecosystems: Option<Vec<String>>,
-    /// Expiration time
-    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
-}
-
 /// Create token response
 #[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -407,17 +395,4 @@ mod tests {
         assert_eq!(response, deserialized);
     }
 
-    // Test 16: CreateTokenRequest deserialization
-    #[test]
-    fn test_create_token_request_deserialization() {
-        let json = r#"{"name": "test-token", "allowed_ecosystems": ["pypi", "cargo"]}"#;
-        let request: CreateTokenRequest = serde_json::from_str(json).unwrap();
-
-        assert_eq!(request.name, "test-token");
-        assert_eq!(
-            request.allowed_ecosystems,
-            Some(vec!["pypi".to_string(), "cargo".to_string()])
-        );
-        assert!(request.expires_at.is_none());
-    }
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -394,5 +394,4 @@ mod tests {
 
         assert_eq!(response, deserialized);
     }
-
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -120,22 +120,22 @@ impl BlockLogEntry {
 
 /// Mask an IP address for privacy (e.g., "192.168.1.100" -> "192.168.x.x")
 fn mask_ip(ip: &str) -> String {
-    // Strict IPv4 validation: exactly 4 octets, each 0-255
-    let parts: Vec<&str> = ip.split('.').collect();
-    if parts.len() == 4 && parts.iter().all(|p| p.parse::<u8>().is_ok()) {
-        return format!("{}.{}.x.x", parts[0], parts[1]);
+    use std::net::IpAddr;
+    match ip.parse::<IpAddr>() {
+        Ok(IpAddr::V4(addr)) => {
+            let octets = addr.octets();
+            format!("{}.{}.x.x", octets[0], octets[1])
+        }
+        Ok(IpAddr::V6(addr)) => {
+            let segments = addr.segments();
+            let half = segments.len() / 2;
+            let prefix: Vec<String> = segments[..half].iter().map(|s| format!("{:x}", s)).collect();
+            let masked_count = segments.len() - half;
+            let mask = vec!["x"; masked_count].join(":");
+            format!("{}:{}", prefix.join(":"), mask)
+        }
+        Err(_) => "x.x.x.x".to_string(),
     }
-    // IPv6: mask last half of segments
-    if ip.contains(':') {
-        let segments: Vec<&str> = ip.split(':').collect();
-        let half = segments.len() / 2;
-        let prefix: Vec<&str> = segments[..half].to_vec();
-        let masked_count = segments.len() - half;
-        let mask = vec!["x"; masked_count].join(":");
-        return format!("{}:{}", prefix.join(":"), mask);
-    }
-    // Unparseable: fully mask
-    "x.x.x.x".to_string()
 }
 
 impl From<BlockLog> for BlockLogEntry {
@@ -439,7 +439,7 @@ mod tests {
     // Test: mask_ip with IPv6 addresses
     #[test]
     fn test_mask_ip_ipv6() {
-        let masked = mask_ip("2001:db8:85a3:8d3:1319:8a2e:370:7348");
+        let masked = mask_ip("2001:0db8:85a3:08d3:1319:8a2e:0370:7348");
         assert!(masked.starts_with("2001:db8:85a3:8d3:"));
         assert!(masked.ends_with(":x:x:x:x"));
     }
@@ -448,5 +448,33 @@ mod tests {
     #[test]
     fn test_mask_ip_invalid() {
         assert_eq!(mask_ip("invalid"), "x.x.x.x");
+    }
+
+    // Test: mask_ip with IPv6 compressed form
+    #[test]
+    fn test_mask_ip_ipv6_compressed() {
+        let masked = mask_ip("::1");
+        // ::1 expands to 0:0:0:0:0:0:0:1, first half preserved, last half masked
+        assert!(masked.starts_with("0:0:0:0:"));
+        assert!(masked.ends_with(":x:x:x:x"));
+    }
+
+    // Test: CreateTokenResponse Debug redacts token
+    #[test]
+    fn test_create_token_response_debug_redacts_token() {
+        let response = CreateTokenResponse {
+            id: "test-id".to_string(),
+            name: "test-name".to_string(),
+            token: "secret-token-value".to_string(),
+            created_at: Utc::now(),
+            expires_at: None,
+        };
+
+        let debug_output = format!("{:?}", response);
+
+        assert!(!debug_output.contains("secret-token-value"));
+        assert!(debug_output.contains("<redacted>"));
+        assert!(debug_output.contains("test-id"));
+        assert!(debug_output.contains("test-name"));
     }
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -336,6 +336,14 @@ mod tests {
 
         assert_eq!(info.id, "test-id");
         assert_eq!(info.name, "test-token");
+        assert!(
+            info.token_prefix.starts_with("rf_"),
+            "token_prefix should start with rf_ prefix"
+        );
+        assert!(
+            info.token_prefix.ends_with("***"),
+            "token_prefix should be masked with ***"
+        );
     }
 
     // Test 13: DashboardStats serialization

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -64,21 +64,8 @@ impl Default for DashboardStats {
     }
 }
 
-/// Security source summary for dashboard
-#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct SecuritySourceSummary {
-    /// Source name
-    pub name: String,
-    /// Supported ecosystems
-    pub ecosystems: Vec<String>,
-    /// Last sync time
-    pub last_sync: Option<chrono::DateTime<chrono::Utc>>,
-    /// Current status
-    pub status: String,
-    /// Number of records
-    pub records_count: u64,
-}
+/// Security source summary for dashboard (alias for SecuritySourceInfo)
+pub type SecuritySourceSummary = SecuritySourceInfo;
 
 /// Block logs query parameters
 #[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
@@ -116,10 +103,28 @@ pub struct BlockLogEntry {
     pub source: String,
     /// Block reason
     pub reason: Option<String>,
-    /// Client IP
+    /// Client IP (masked for privacy, e.g. "192.168.x.x")
     pub client_ip: Option<String>,
     /// Timestamp
     pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+/// Mask an IP address for privacy (e.g., "192.168.1.100" -> "192.168.x.x")
+fn mask_ip(ip: &str) -> String {
+    if let Some(dot_pos) = ip.find('.') {
+        if let Some(second_dot) = ip[dot_pos + 1..].find('.') {
+            let prefix = &ip[..dot_pos + 1 + second_dot];
+            return format!("{}.x.x", prefix);
+        }
+    }
+    // IPv6 or unparseable: mask last half
+    if ip.contains(':') {
+        let parts: Vec<&str> = ip.split(':').collect();
+        let half = parts.len() / 2;
+        let prefix: Vec<&str> = parts[..half].to_vec();
+        return format!("{}:x:x:x", prefix.join(":"));
+    }
+    "x.x.x.x".to_string()
 }
 
 impl From<BlockLog> for BlockLogEntry {
@@ -131,7 +136,7 @@ impl From<BlockLog> for BlockLogEntry {
             version: log.version,
             source: log.source,
             reason: log.reason,
-            client_ip: log.client_ip,
+            client_ip: log.client_ip.as_deref().map(mask_ip),
             timestamp: log.timestamp,
         }
     }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -34,6 +34,7 @@ pub const TOKEN_MASK_PREFIX_LENGTH: usize = 8;
 // =============================================================================
 
 /// Dashboard statistics response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DashboardStats {
     /// Total number of requests processed
@@ -64,6 +65,7 @@ impl Default for DashboardStats {
 }
 
 /// Security source summary for dashboard
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SecuritySourceSummary {
     /// Source name
@@ -79,6 +81,7 @@ pub struct SecuritySourceSummary {
 }
 
 /// Block logs query parameters
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct BlockLogsQuery {
     /// Number of logs to return (default: 50)
@@ -88,6 +91,7 @@ pub struct BlockLogsQuery {
 }
 
 /// Block logs response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BlockLogsResponse {
     /// Block log entries
@@ -97,6 +101,7 @@ pub struct BlockLogsResponse {
 }
 
 /// Block log entry for API response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BlockLogEntry {
     /// Log ID
@@ -133,6 +138,7 @@ impl From<BlockLog> for BlockLogEntry {
 }
 
 /// Security sources response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SecuritySourcesResponse {
     /// List of security sources
@@ -140,6 +146,7 @@ pub struct SecuritySourcesResponse {
 }
 
 /// Security source information
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SecuritySourceInfo {
     /// Source name
@@ -155,6 +162,7 @@ pub struct SecuritySourceInfo {
 }
 
 /// Sync trigger response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SyncTriggerResponse {
     /// Response message
@@ -166,6 +174,7 @@ pub struct SyncTriggerResponse {
 }
 
 /// Cache statistics response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CacheStatsResponse {
     /// Cache plugin name
@@ -181,6 +190,7 @@ pub struct CacheStatsResponse {
 }
 
 /// Cache clear response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CacheClearResponse {
     /// Response message
@@ -188,6 +198,7 @@ pub struct CacheClearResponse {
 }
 
 /// Rules list response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RulesResponse {
     /// List of custom rules
@@ -195,6 +206,7 @@ pub struct RulesResponse {
 }
 
 /// Token list response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TokensResponse {
     /// List of tokens (without hashes)
@@ -202,6 +214,7 @@ pub struct TokensResponse {
 }
 
 /// Token information (safe to return - never exposes full token value)
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TokenInfo {
     /// Token ID
@@ -240,6 +253,7 @@ impl From<&Token> for TokenInfo {
 }
 
 /// Create token request
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Deserialize)]
 pub struct CreateTokenRequest {
     /// Token name
@@ -251,6 +265,7 @@ pub struct CreateTokenRequest {
 }
 
 /// Create token response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CreateTokenResponse {
     /// Token ID
@@ -266,6 +281,7 @@ pub struct CreateTokenResponse {
 }
 
 /// Generic message response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MessageResponse {
     /// Response message
@@ -273,6 +289,7 @@ pub struct MessageResponse {
 }
 
 /// Error response
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ErrorResponse {
     /// Error message

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate provides a proxy server that filters malicious packages and versions
 //! from package registries like PyPI, Go modules, Cargo, and Docker.
 
+pub mod api;
 pub mod auth;
 pub mod config;
 pub mod database;
@@ -12,4 +13,5 @@ pub mod otel;
 pub mod plugins;
 pub mod server;
 pub mod sync;
+#[cfg(feature = "webui")]
 pub mod webui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,7 @@ async fn main() -> anyhow::Result<()> {
         let spec = ApiDoc::openapi()
             .to_pretty_json()
             .expect("Failed to serialize OpenAPI spec");
-        std::fs::write("swagger.json", &spec)
-            .expect("Failed to write swagger.json");
+        std::fs::write("swagger.json", &spec).expect("Failed to write swagger.json");
         eprintln!("swagger.json generated successfully ({} bytes)", spec.len());
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,8 @@ async fn main() -> anyhow::Result<()> {
         use utoipa::OpenApi;
         let spec = ApiDoc::openapi()
             .to_pretty_json()
-            .expect("Failed to serialize OpenAPI spec");
-        std::fs::write("swagger.json", &spec).expect("Failed to write swagger.json");
+            .map_err(|e| anyhow::anyhow!("Failed to serialize OpenAPI spec: {}", e))?;
+        std::fs::write("swagger.json", &spec)?;
         eprintln!("swagger.json generated successfully ({} bytes)", spec.len());
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,31 @@ struct Args {
     /// Path to the configuration file
     #[arg(short, long, env = "REGISTRY_FIREWALL_CONFIG")]
     config: Option<String>,
+
+    /// Generate OpenAPI specification (swagger.json) and exit
+    #[cfg(feature = "swagger-gen")]
+    #[arg(long)]
+    generate_swagger: bool,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Parse CLI arguments
     let args = Args::parse();
+
+    // Generate swagger.json if requested
+    #[cfg(feature = "swagger-gen")]
+    if args.generate_swagger {
+        use registry_firewall::api::openapi::ApiDoc;
+        use utoipa::OpenApi;
+        let spec = ApiDoc::openapi()
+            .to_pretty_json()
+            .expect("Failed to serialize OpenAPI spec");
+        std::fs::write("swagger.json", &spec)
+            .expect("Failed to write swagger.json");
+        eprintln!("swagger.json generated successfully ({} bytes)", spec.len());
+        return Ok(());
+    }
 
     // Load configuration
     let config = load_config(&args)?;

--- a/src/models/block.rs
+++ b/src/models/block.rs
@@ -273,6 +273,7 @@ impl BlockLog {
 }
 
 /// Custom block rule
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CustomRule {
     /// Database ID (optional, set after insertion)

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -27,6 +27,13 @@ use crate::api::{
     self, BlockLogsQuery, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, MAX_PATTERN_LENGTH,
     MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
 };
+#[cfg(feature = "swagger-gen")]
+use crate::api::{
+    BlockLogsResponse, CacheClearResponse, CacheStatsResponse, DashboardStats,
+    SecuritySourcesResponse,
+};
+#[cfg(feature = "swagger-gen")]
+use crate::models::CustomRule;
 
 /// Shared application state
 pub struct AppState<D: Database> {

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -18,8 +18,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::api::{
-    self, BlockLogsQuery, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, MAX_PATTERN_LENGTH,
-    MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
+    self, BlockLogsQuery, CreateTokenApiRequest, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT,
+    MAX_PATTERN_LENGTH, MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
 };
 #[cfg(feature = "swagger-gen")]
 use crate::api::{
@@ -130,6 +130,17 @@ pub fn build_router<D: Database + 'static>(state: AppState<D>) -> Router {
     let router = router
         .route("/ui", get(webui_index_handler))
         .route("/ui/*path", get(webui_static_handler));
+
+    // Swagger UI endpoint (requires both webui and swagger-gen features)
+    #[cfg(all(feature = "webui", feature = "swagger-gen"))]
+    let router = {
+        use crate::api::openapi::ApiDoc;
+        use utoipa::OpenApi;
+        router.merge(
+            utoipa_swagger_ui::SwaggerUi::new("/api/swagger-ui")
+                .url("/api/openapi.json", ApiDoc::openapi()),
+        )
+    };
 
     router
         // Apply authentication middleware
@@ -734,15 +745,6 @@ pub(crate) async fn api_list_tokens_handler<D: Database + 'static>(
             )
         }
     }
-}
-
-/// Create token request
-#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
-#[derive(Debug, Deserialize)]
-pub struct CreateTokenApiRequest {
-    pub name: String,
-    pub allowed_ecosystems: Option<Vec<String>>,
-    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// Create token handler

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -17,12 +17,6 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-use crate::auth::AuthManager;
-use crate::database::Database;
-use crate::plugins::cache::traits::CachePlugin;
-use crate::plugins::registry::RegistryPlugin;
-use crate::plugins::security::traits::SecuritySourcePlugin;
-use crate::server::middleware::auth_middleware;
 use crate::api::{
     self, BlockLogsQuery, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, MAX_PATTERN_LENGTH,
     MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
@@ -32,8 +26,14 @@ use crate::api::{
     BlockLogsResponse, CacheClearResponse, CacheStatsResponse, DashboardStats,
     SecuritySourcesResponse,
 };
+use crate::auth::AuthManager;
+use crate::database::Database;
 #[cfg(feature = "swagger-gen")]
 use crate::models::CustomRule;
+use crate::plugins::cache::traits::CachePlugin;
+use crate::plugins::registry::RegistryPlugin;
+use crate::plugins::security::traits::SecuritySourcePlugin;
+use crate::server::middleware::auth_middleware;
 
 /// Shared application state
 pub struct AppState<D: Database> {

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -293,7 +293,16 @@ async fn registry_proxy_handler<D: Database + 'static>(
 // =============================================================================
 
 /// Dashboard API handler
-async fn api_dashboard_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    get,
+    path = "/api/dashboard",
+    responses(
+        (status = 200, description = "Dashboard statistics", body = DashboardStats),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "dashboard"
+))]
+pub(crate) async fn api_dashboard_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
 ) -> impl IntoResponse {
     let stats = api::build_dashboard_stats(
@@ -310,7 +319,20 @@ async fn api_dashboard_handler<D: Database + 'static>(
 /// Query parameters:
 /// - `limit`: Number of logs to return (default: 50, max: 1000)
 /// - `offset`: Pagination offset (default: 0)
-async fn api_blocks_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    get,
+    path = "/api/blocks",
+    params(
+        ("limit" = Option<u32>, Query, description = "Number of logs to return"),
+        ("offset" = Option<u32>, Query, description = "Pagination offset"),
+    ),
+    responses(
+        (status = 200, description = "Block logs", body = BlockLogsResponse),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "blocks"
+))]
+pub(crate) async fn api_blocks_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
     Query(query): Query<BlockLogsQuery>,
 ) -> impl IntoResponse {
@@ -338,7 +360,16 @@ async fn api_blocks_handler<D: Database + 'static>(
 }
 
 /// Security sources status API handler
-async fn api_security_sources_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    get,
+    path = "/api/security-sources",
+    responses(
+        (status = 200, description = "Security sources list", body = SecuritySourcesResponse),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "security-sources"
+))]
+pub(crate) async fn api_security_sources_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
 ) -> impl IntoResponse {
     let response = api::build_security_sources_response(&state.security_plugins);
@@ -346,7 +377,19 @@ async fn api_security_sources_handler<D: Database + 'static>(
 }
 
 /// Trigger sync for a security source
-async fn api_trigger_sync_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    post,
+    path = "/api/security-sources/{name}/sync",
+    params(
+        ("name" = String, Path, description = "Security source name"),
+    ),
+    responses(
+        (status = 200, description = "Sync triggered"),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "security-sources"
+))]
+pub(crate) async fn api_trigger_sync_handler<D: Database + 'static>(
     State(_state): State<AppState<D>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
@@ -357,7 +400,16 @@ async fn api_trigger_sync_handler<D: Database + 'static>(
 }
 
 /// Cache stats API handler
-async fn api_cache_stats_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    get,
+    path = "/api/cache/stats",
+    responses(
+        (status = 200, description = "Cache statistics", body = CacheStatsResponse),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "cache"
+))]
+pub(crate) async fn api_cache_stats_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
 ) -> impl IntoResponse {
     let stats = api::get_cache_stats(&state.cache_plugin).await;
@@ -365,7 +417,16 @@ async fn api_cache_stats_handler<D: Database + 'static>(
 }
 
 /// Cache clear API handler
-async fn api_cache_clear_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    delete,
+    path = "/api/cache",
+    responses(
+        (status = 200, description = "Cache cleared", body = CacheClearResponse),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "cache"
+))]
+pub(crate) async fn api_cache_clear_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
 ) -> impl IntoResponse {
     match api::clear_cache(&state.cache_plugin).await {
@@ -388,7 +449,16 @@ async fn api_cache_clear_handler<D: Database + 'static>(
 }
 
 /// List custom rules handler
-async fn api_list_rules_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    get,
+    path = "/api/rules",
+    responses(
+        (status = 200, description = "Custom rules list"),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "rules"
+))]
+pub(crate) async fn api_list_rules_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
 ) -> impl IntoResponse {
     match state.database.list_rules().await {
@@ -409,7 +479,17 @@ async fn api_list_rules_handler<D: Database + 'static>(
 /// - package_pattern: required, max 512 characters
 /// - version_constraint: optional, max 512 characters
 /// - reason: optional, max 1024 characters
-async fn api_create_rule_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    post,
+    path = "/api/rules",
+    request_body = CustomRule,
+    responses(
+        (status = 201, description = "Rule created"),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "rules"
+))]
+pub(crate) async fn api_create_rule_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
     Json(rule): Json<crate::models::CustomRule>,
 ) -> impl IntoResponse {
@@ -467,7 +547,20 @@ async fn api_create_rule_handler<D: Database + 'static>(
 }
 
 /// Get custom rule by ID handler
-async fn api_get_rule_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    get,
+    path = "/api/rules/{id}",
+    params(
+        ("id" = i64, Path, description = "Rule ID"),
+    ),
+    responses(
+        (status = 200, description = "Custom rule"),
+        (status = 404, description = "Rule not found"),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "rules"
+))]
+pub(crate) async fn api_get_rule_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
     Path(id): Path<i64>,
 ) -> impl IntoResponse {
@@ -493,7 +586,20 @@ async fn api_get_rule_handler<D: Database + 'static>(
 /// - package_pattern: required, max 512 characters
 /// - version_constraint: optional, max 512 characters
 /// - reason: optional, max 1024 characters
-async fn api_update_rule_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    put,
+    path = "/api/rules/{id}",
+    params(
+        ("id" = i64, Path, description = "Rule ID"),
+    ),
+    request_body = CustomRule,
+    responses(
+        (status = 200, description = "Rule updated"),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "rules"
+))]
+pub(crate) async fn api_update_rule_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
     Path(id): Path<i64>,
     Json(mut rule): Json<crate::models::CustomRule>,
@@ -556,7 +662,19 @@ async fn api_update_rule_handler<D: Database + 'static>(
 /// Delete custom rule handler
 ///
 /// Returns 204 No Content on success (REST best practice for DELETE).
-async fn api_delete_rule_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    delete,
+    path = "/api/rules/{id}",
+    params(
+        ("id" = i64, Path, description = "Rule ID"),
+    ),
+    responses(
+        (status = 204, description = "Rule deleted"),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "rules"
+))]
+pub(crate) async fn api_delete_rule_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
     Path(id): Path<i64>,
 ) -> impl IntoResponse {
@@ -579,7 +697,16 @@ async fn api_delete_rule_handler<D: Database + 'static>(
 ///
 /// Returns token metadata with masked token prefix for identification.
 /// Full token values are never exposed after creation.
-async fn api_list_tokens_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    get,
+    path = "/api/tokens",
+    responses(
+        (status = 200, description = "Token list"),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "tokens"
+))]
+pub(crate) async fn api_list_tokens_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
 ) -> impl IntoResponse {
     match state.auth_manager.list_tokens().await {
@@ -603,6 +730,7 @@ async fn api_list_tokens_handler<D: Database + 'static>(
 }
 
 /// Create token request
+#[cfg_attr(feature = "swagger-gen", derive(utoipa::ToSchema))]
 #[derive(Debug, Deserialize)]
 pub struct CreateTokenApiRequest {
     pub name: String,
@@ -611,7 +739,17 @@ pub struct CreateTokenApiRequest {
 }
 
 /// Create token handler
-async fn api_create_token_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    post,
+    path = "/api/tokens",
+    request_body = CreateTokenApiRequest,
+    responses(
+        (status = 201, description = "Token created"),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "tokens"
+))]
+pub(crate) async fn api_create_token_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
     Json(req): Json<CreateTokenApiRequest>,
 ) -> impl IntoResponse {
@@ -664,7 +802,19 @@ async fn api_create_token_handler<D: Database + 'static>(
 ///
 /// Returns 204 No Content on success (REST best practice for DELETE).
 /// Token ID is logged for audit purposes (never the token value).
-async fn api_delete_token_handler<D: Database + 'static>(
+#[cfg_attr(feature = "swagger-gen", utoipa::path(
+    delete,
+    path = "/api/tokens/{id}",
+    params(
+        ("id" = String, Path, description = "Token ID"),
+    ),
+    responses(
+        (status = 204, description = "Token revoked"),
+    ),
+    security(("bearer_token" = []), ("basic_auth" = [])),
+    tag = "tokens"
+))]
+pub(crate) async fn api_delete_token_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -18,8 +18,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::api::{
-    self, BlockLogsQuery, CreateTokenApiRequest, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT,
-    MAX_PATTERN_LENGTH, MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
+    self, BlockLogsQuery, CreateTokenApiRequest, MAX_PATTERN_LENGTH, MAX_REASON_LENGTH,
+    MAX_TOKEN_NAME_LENGTH,
 };
 #[cfg(feature = "swagger-gen")]
 use crate::api::{
@@ -352,12 +352,8 @@ pub(crate) async fn api_blocks_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
     Query(query): Query<BlockLogsQuery>,
 ) -> impl IntoResponse {
-    // Validate and apply limits using constants
-    let limit = query
-        .limit
-        .unwrap_or(DEFAULT_PAGE_LIMIT)
-        .min(MAX_PAGE_LIMIT);
-    let offset = query.offset.unwrap_or(0);
+    let limit = query.normalized_limit();
+    let offset = query.normalized_offset();
 
     match api::get_block_logs(state.database.as_ref(), limit, offset).await {
         Ok(response) => (StatusCode::OK, Json(response)),

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -23,7 +23,7 @@ use crate::plugins::cache::traits::CachePlugin;
 use crate::plugins::registry::RegistryPlugin;
 use crate::plugins::security::traits::SecuritySourcePlugin;
 use crate::server::middleware::auth_middleware;
-use crate::webui::api::{
+use crate::api::{
     self, BlockLogsQuery, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT, MAX_PATTERN_LENGTH,
     MAX_REASON_LENGTH, MAX_TOKEN_NAME_LENGTH,
 };
@@ -86,7 +86,7 @@ pub struct MetricsResponse {
 pub fn build_router<D: Database + 'static>(state: AppState<D>) -> Router {
     let auth_manager = Arc::clone(&state.auth_manager);
 
-    Router::new()
+    let router = Router::new()
         // Health and metrics endpoints (no auth required)
         .route("/health", get(health_handler))
         .route("/metrics", get(metrics_handler))
@@ -116,10 +116,15 @@ pub fn build_router<D: Database + 'static>(state: AppState<D>) -> Router {
         .route("/api/rules/:id", delete(api_delete_rule_handler::<D>))
         .route("/api/tokens", get(api_list_tokens_handler::<D>))
         .route("/api/tokens", post(api_create_token_handler::<D>))
-        .route("/api/tokens/:id", delete(api_delete_token_handler::<D>))
-        // Web UI routes
+        .route("/api/tokens/:id", delete(api_delete_token_handler::<D>));
+
+    // Web UI routes (only when webui feature is enabled)
+    #[cfg(feature = "webui")]
+    let router = router
         .route("/ui", get(webui_index_handler))
-        .route("/ui/*path", get(webui_static_handler))
+        .route("/ui/*path", get(webui_static_handler));
+
+    router
         // Apply authentication middleware
         .layer(middleware::from_fn_with_state(
             auth_manager,
@@ -684,11 +689,13 @@ async fn api_delete_token_handler<D: Database + 'static>(
 // =============================================================================
 
 /// Web UI index handler
+#[cfg(feature = "webui")]
 async fn webui_index_handler() -> impl IntoResponse {
     crate::webui::serve_index()
 }
 
 /// Web UI static file handler
+#[cfg(feature = "webui")]
 async fn webui_static_handler(Path(path): Path<String>) -> impl IntoResponse {
     crate::webui::serve_static(&path)
 }
@@ -889,6 +896,7 @@ mod tests {
     }
 
     // Test 13: Web UI index endpoint
+    #[cfg(feature = "webui")]
     #[tokio::test]
     async fn test_webui_index_endpoint() {
         let state = create_test_state();
@@ -900,6 +908,7 @@ mod tests {
     }
 
     // Test 14: Web UI static files endpoint
+    #[cfg(feature = "webui")]
     #[tokio::test]
     async fn test_webui_static_endpoint() {
         let state = create_test_state();

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -312,13 +312,22 @@ async fn registry_proxy_handler<D: Database + 'static>(
 pub(crate) async fn api_dashboard_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
 ) -> impl IntoResponse {
-    let stats = api::build_dashboard_stats(
+    match api::build_dashboard_stats(
         state.database.as_ref(),
         &state.security_plugins,
         &state.cache_plugin,
     )
-    .await;
-    Json(stats)
+    .await
+    {
+        Ok(stats) => (StatusCode::OK, Json(serde_json::to_value(stats).unwrap())),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to build dashboard stats");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to fetch dashboard statistics" })),
+            )
+        }
+    }
 }
 
 /// Block logs API handler
@@ -400,10 +409,12 @@ pub(crate) async fn api_trigger_sync_handler<D: Database + 'static>(
     State(_state): State<AppState<D>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    // TODO: Implement manual sync trigger
-    Json(serde_json::json!({
-        "message": format!("Sync triggered for {}", name)
-    }))
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(serde_json::json!({
+            "error": format!("Manual sync trigger for '{}' is not yet implemented", name)
+        })),
+    )
 }
 
 /// Cache stats API handler
@@ -480,6 +491,39 @@ pub(crate) async fn api_list_rules_handler<D: Database + 'static>(
     }
 }
 
+/// Validate custom rule fields
+fn validate_custom_rule(
+    rule: &crate::models::CustomRule,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if rule.package_pattern.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "Package pattern cannot be empty" })),
+        ));
+    }
+    if rule.package_pattern.len() > MAX_PATTERN_LENGTH {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "Package pattern exceeds maximum length" })),
+        ));
+    }
+    if rule.version_constraint.len() > MAX_PATTERN_LENGTH {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "Version constraint exceeds maximum length" })),
+        ));
+    }
+    if let Some(ref reason) = rule.reason {
+        if reason.len() > MAX_REASON_LENGTH {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "Reason exceeds maximum length" })),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Create custom rule handler
 ///
 /// Validates rule fields before insertion:
@@ -500,36 +544,8 @@ pub(crate) async fn api_create_rule_handler<D: Database + 'static>(
     State(state): State<AppState<D>>,
     Json(rule): Json<crate::models::CustomRule>,
 ) -> impl IntoResponse {
-    // Validate package_pattern
-    if rule.package_pattern.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "Package pattern cannot be empty" })),
-        );
-    }
-    if rule.package_pattern.len() > MAX_PATTERN_LENGTH {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "Package pattern exceeds maximum length" })),
-        );
-    }
-
-    // Validate version_constraint
-    if rule.version_constraint.len() > MAX_PATTERN_LENGTH {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "Version constraint exceeds maximum length" })),
-        );
-    }
-
-    // Validate reason if provided
-    if let Some(ref reason) = rule.reason {
-        if reason.len() > MAX_REASON_LENGTH {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "error": "Reason exceeds maximum length" })),
-            );
-        }
+    if let Err(response) = validate_custom_rule(&rule) {
+        return response;
     }
 
     tracing::info!(
@@ -611,36 +627,8 @@ pub(crate) async fn api_update_rule_handler<D: Database + 'static>(
     Path(id): Path<i64>,
     Json(mut rule): Json<crate::models::CustomRule>,
 ) -> impl IntoResponse {
-    // Validate package_pattern
-    if rule.package_pattern.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "Package pattern cannot be empty" })),
-        );
-    }
-    if rule.package_pattern.len() > MAX_PATTERN_LENGTH {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "Package pattern exceeds maximum length" })),
-        );
-    }
-
-    // Validate version_constraint
-    if rule.version_constraint.len() > MAX_PATTERN_LENGTH {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": "Version constraint exceeds maximum length" })),
-        );
-    }
-
-    // Validate reason if provided
-    if let Some(ref reason) = rule.reason {
-        if reason.len() > MAX_REASON_LENGTH {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "error": "Reason exceeds maximum length" })),
-            );
-        }
+    if let Err(response) = validate_custom_rule(&rule) {
+        return response;
     }
 
     tracing::info!(

--- a/src/server/router.rs
+++ b/src/server/router.rs
@@ -131,17 +131,6 @@ pub fn build_router<D: Database + 'static>(state: AppState<D>) -> Router {
         .route("/ui", get(webui_index_handler))
         .route("/ui/*path", get(webui_static_handler));
 
-    // Swagger UI endpoint (requires both webui and swagger-gen features)
-    #[cfg(all(feature = "webui", feature = "swagger-gen"))]
-    let router = {
-        use crate::api::openapi::ApiDoc;
-        use utoipa::OpenApi;
-        router.merge(
-            utoipa_swagger_ui::SwaggerUi::new("/api/swagger-ui")
-                .url("/api/openapi.json", ApiDoc::openapi()),
-        )
-    };
-
     router
         // Apply authentication middleware
         .layer(middleware::from_fn_with_state(

--- a/src/webui/mod.rs
+++ b/src/webui/mod.rs
@@ -1,12 +1,7 @@
 //! Web UI backend module
 //!
 //! This module provides the backend functionality for the Web UI including:
-//! - REST API endpoints for dashboard, blocks, rules, tokens, etc.
 //! - Static file embedding and serving (via rust-embed)
-
-pub mod api;
-
-pub use api::*;
 
 use axum::{
     body::Body,


### PR DESCRIPTION
## Summary

- Cargo featuresで`webui`モジュールをオプション化し、API-onlyとFull(GUI付き)の2種類のDockerイメージをリリース可能にした
- `utoipa`クレートによるOpenAPI/Swagger仕様の自動生成機能を追加
- GitHub Actionsで2イメージの並列ビルドと`swagger.json`のリリースアセット添付を実装

## Changes

### Cargo Features
- `webui` feature (default): Web UIの静的ファイル埋め込み
- `swagger-gen` feature: utoipaによるOpenAPI仕様生成

### Module Restructuring
- `src/webui/api.rs` → `src/api/` に移動（feature非依存化）
- `src/webui/mod.rs` は静的ファイル配信のみに限定
- `/ui/*` ルートを `cfg(feature = "webui")` で条件付きコンパイル

### Docker Images
- `Dockerfile`: API-only (`--no-default-features`)、`latest`/`X.Y.Z` タグ
- `Dockerfile.full`: GUI付き（node-buildステージ + `--features webui`）、`latest-full`/`X.Y.Z-full` タグ

### OpenAPI/Swagger
- 全14 APIエンドポイントに `utoipa::path` アノテーション
- 全API型に `ToSchema` derive
- `--generate-swagger` CLIオプションで `swagger.json` 出力
- リリース時に `swagger.json` をGitHubリリースアセットに添付

### CI/CD
- `test-no-default-features` ジョブ追加（API-onlyビルド検証）
- Docker build checkに `Dockerfile.full` 追加
- リリースワークフローで3ジョブ並列実行（API image / Full image / Swagger生成）

## SDD Documents
- `docs/sdd/requirements-dual-docker.md` - EARS記法による要件定義
- `docs/sdd/design-dual-docker.md` - 技術設計書
- `docs/sdd/tasks-dual-docker.md` - 実装タスク計画

## Test plan
- [ ] `cargo build --no-default-features` が成功すること
- [ ] `cargo build --all-features` が成功すること
- [ ] `cargo test --no-default-features` が全パスすること
- [ ] `cargo test --all-features` が全パスすること
- [ ] `cargo clippy --all-features -- -D warnings` がパスすること
- [ ] CI の Docker build check が両Dockerfileで成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * API専用イメージとWeb UI搭載フルイメージを個別にビルド・公開できるリリースフローを追加
  * CLIでOpenAPI（swagger.json）を生成してリリース資産に添付可能に
  * ダッシュボード、ブロックログ、セキュリティソース、キャッシュ、ルール、トークン等のREST APIと対応スキーマを追加

* **改善**
  * CIを機能オン/オフ別に分割して並列検証を強化
  * Dockerビルドにキャッシュ最適化とマルチアーキ対応を導入
  * Web UI／OpenAPI機能をフラグで切替可能に

* **ドキュメント**
  * デュアルイメージ設計、要件、タスク計画、リリース手順、OpenAPI運用を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->